### PR TITLE
Catch OSError when spawning subprocess.

### DIFF
--- a/powerline-bash.py
+++ b/powerline-bash.py
@@ -91,6 +91,9 @@ def add_svn_segment(powerline):
         if len(output) > 0 and int(output) > 0:
           changes = output.strip()
           p.append(' ' + changes + ' ', 22, 148)
+    # if svn or grep is not installed on the machine
+    except OSError:
+      pass
     except subprocess.CalledProcessError:
       pass
 


### PR DESCRIPTION
I didn't have svn installed on my machine so it exploded with:

Traceback (most recent call last):
  File "/Users/pjn/powerline-bash.py", line 128, in <module>
    add_svn_segment(p)
  File "/Users/pjn/powerline-bash.py", line 88, in add_svn_segment
    p1 = subprocess.Popen(['svn', 'status'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 679, in **init**
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 1228, in _execute_child
OSError: [Errno 2] No such file or directory

Maybe there is a cleaner way to fix this, but it did the trick.
