### PR TITLE
Use /usr/bin/env python instead of /usr/bin/python

### DIFF
--- a/powerline-bash.py
+++ b/powerline-bash.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 import os


### PR DESCRIPTION
I had some problems on a virtual machine due to an older version of Python being on the system at /usr/bin/python.

This is awesome by the way!
