### PR TITLE
Remove the grep command from hg status

### DIFF
--- a/powerline-bash.py
+++ b/powerline-bash.py
@@ -73,7 +73,7 @@ def add_cwd_segment(powerline, cwd, maxdepth):
     powerline.append(Segment(' %s ' % names[-1], 254, 237))
 
 def is_hg_clean():
-    output = os.popen("hg status 2> /dev/null | grep '^?' | tail -n1").read()
+    output = os.popen("hg status 2> /dev/null | tail -n1").read()
     return len(output) == 0
 
 def add_hg_segment(powerline, cwd):


### PR DESCRIPTION
If anything, I guess you can remove the grep on hg completely. The correction earlier made it only highlight as changed on files that hadn't been added to the repo yet, which in my opinion were the least interesting ones (they won't get added if you do a "hg commit" as the other flags would).
Removing the grep completely makes it highlight any change to the repo, including untracked files which I guess might be the best behaviour? I don't know!
