### PR TITLE
Fixing git status for git 1.8

### DIFF
--- a/powerline-bash.py
+++ b/powerline-bash.py
@@ -115,7 +115,7 @@ def get_git_status():
             if origin_status[0][0] == 'ahead':
                 origin_position += u'\u21E1'
 
-        if line.find('nothing to commit (working directory clean)') >= 0:
+        if line.find('nothing to commit') >= 0:
             has_pending_commits = False
         if line.find('Untracked files') >= 0:
             has_untracked_files = True


### PR DESCRIPTION
Git 1.8 slightly changed the output text of  `status`, breaking the indication of when the working directory was clean.
