### PR TITLE
Skip git submodule status check

### DIFF
--- a/powerline-bash.py
+++ b/powerline-bash.py
@@ -124,7 +124,7 @@ def get_git_status():
     has_pending_commits = True
     has_untracked_files = False
     origin_position = ""
-    output = subprocess.Popen(['git', 'status'], stdout=subprocess.PIPE).communicate()[0]
+    output = subprocess.Popen(['git', 'status', '--ignore-submodules'], stdout=subprocess.PIPE).communicate()[0]
     for line in output.split('\n'):
         origin_status = re.findall("Your branch is (ahead|behind).*?(\d+) comm", line)
         if len(origin_status) > 0:


### PR DESCRIPTION
At $DAY_JOB we use submodules and when I enter the top directory with powerline-bash it seems to hang. This is due to git status (recursive w/ submodules) issuing around 300 000 lstat() calls over our repos. Not sure if this is the best solution but at least powerline-bash becomes more usable in this setup with this fix.
