### PR TITLE
Refactor the way colors are defined

### DIFF
--- a/powerline-bash.py
+++ b/powerline-bash.py
@@ -12,7 +12,6 @@ class Color:
 
     PATH_BG = 237 # dark grey
     PATH_FG = 250 # light grey
-    CWD_BG = 237
     CWD_FG = 254 # nearly-white grey
     SEPARATOR_FG = 244
 
@@ -107,7 +106,7 @@ def add_cwd_segment(powerline, cwd, maxdepth):
 
     for n in names[:-1]:
         powerline.append(Segment(powerline, ' %s ' % n, Color.PATH_FG, Color.PATH_BG, powerline.separator_thin, Color.SEPARATOR_FG))
-    powerline.append(Segment(powerline, ' %s ' % names[-1], Color.CWD_FG, Color.CWD_BG))
+    powerline.append(Segment(powerline, ' %s ' % names[-1], Color.CWD_FG, Color.PATH_BG))
 
 def get_hg_status():
     has_modified_files = False


### PR DESCRIPTION
There is now a list of constants at the top of the file that will allow one to easily create a theme for their powerline.

All colors should be exactly the same. The only thing I was unhappy about was that the SVN segment uses a different foreground color. I would have liked to have used the clean repo foreground color.

I committed a bunch. I don't know if that will cause your commit history to be filled with my commits. I can optionally squash all my commits into my master branch and create a new pull request. I don't really know how these things generally play out.
