### PR TITLE
Python version in header

### DIFF
--- a/powerline-bash.py
+++ b/powerline-bash.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 import os


### PR DESCRIPTION
Now script's header points to `python2` not `python`. This fixes that on some system like Arch Linux system tries to run script w/ Python3.
