### PR TITLE
change the method of telling if cwd is a working copy

### DIFF
--- a/powerline-bash.py
+++ b/powerline-bash.py
@@ -226,8 +226,6 @@ def add_git_segment(powerline, cwd):
 def add_svn_segment(powerline, cwd):
     is_svn = subprocess.Popen(['svn', 'status'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     is_svn_output = is_svn.communicate()[1].strip()
-    print is_svn_output
-    print len(is_svn_output)
     if len(is_svn_output) != 0:
         return
 


### PR DESCRIPTION
tell if cwd is a working copy according to the result of 'svn status', not to dir '.svn'.
