### PR TITLE
Add support for Mac os x 10.8.2 's bash

### DIFF
--- a/powerline-bash.py
+++ b/powerline-bash.py
@@ -41,16 +41,12 @@ class Color:
 class Powerline:
     symbols = {
         'compatible': {
-            #'separator': u'\u25B6',
-            'separator': '>',
-        #'separator_thin': u'\u276F'
-	    'separator_thin': '>'
+            'separator': u'\u25B6',
+            'separator_thin': u'\u276F'
         },
         'patched': {
-            #'separator': u'\u2B80',
-            'separator': '>',
-            #'separator_thin': u'\u2B81'
-            'separator_thin': '>'
+            'separator': u'\u2B80',
+            'separator_thin': u'\u2B81'
         },
         # add for support display in mac osx's bash 
         'macosx': {


### PR DESCRIPTION
Add support for Mac os x 10.8.2 's bash
1. osx 10.8.2 has python 2.5/6/7 but don't have link any one of them to python2,
   so i hard code as Python2.7, please update it if you have good idea :-)
1. prompt symbol display error in osx's bash, I add new group names "macosx"
   and code to detect os type, now it works in osx well
