### PR TITLE
svn:externs should not be considered modifications

### DIFF
--- a/powerline-shell.py
+++ b/powerline-shell.py
@@ -238,7 +238,7 @@ def add_svn_segment(powerline, cwd):
         'I' Ignored
         'M' Modified
         'R' Replaced
-        'X' an unversioned directory created by an externals definition
+        'X' a directory pulled in by an svn:externals definition
         '?' item is not under version control
         '!' item is missing (removed by non-svn command) or incomplete
          '~' versioned item obstructed by some item of a different kind
@@ -248,7 +248,7 @@ def add_svn_segment(powerline, cwd):
         #cmd = '"svn status | grep -c "^[ACDIMRX\\!\\~]"'
         p1 = subprocess.Popen(['svn', 'status'], stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE)
-        p2 = subprocess.Popen(['grep', '-c', '^[ACDIMRX\\!\\~]'],
+        p2 = subprocess.Popen(['grep', '-c', '^[ACDIMR\\!\\~]'],
                 stdin=p1.stdout, stdout=subprocess.PIPE)
         output = p2.communicate()[0].strip()
         if len(output) > 0 and int(output) > 0:


### PR DESCRIPTION
As part of my job, I work on a large svn project with a lot of externs (152, to be exact).  powerline-shell wants to track each extern as a modification, so I always have "152 + the actual number of local modifications."  I feel like powerline-shell should ignore those externs as changes.  Svn doesn't consider those to be changes, nor does a top-level "svn commit" spider down into the externs (you have to go into each extern and commit there if you have modifications in them).
