### PR TITLE
Patched font codes did not match Powerline doc

### DIFF
--- a/powerline-shell.py
+++ b/powerline-shell.py
@@ -45,8 +45,8 @@ class Powerline:
             'separator_thin': u'\u276F'
         },
         'patched': {
-            'separator': u'\u2B80',
-            'separator_thin': u'\u2B81'
+            'separator': u'\uE0B0',
+            'separator_thin': u'\uE0B1'
         },
         'flat': {
             'separator': '',


### PR DESCRIPTION
According to Powerline documentation font glyph have following codes: 
U+E0B0  - Rightwards black arrowhead
U+E0B1  - Rightwards arrowhead
https://powerline.readthedocs.org/en/latest/fontpatching.html?highlight=glyph

**Steps to reproduce:**

Install patched font from Powerline fonts repository:

``` bash
sudo mkdir -p /usr/share/fonts/opentype
sudo wget -P /usr/share/fonts/opentype "https://github.com/Lokaltog/powerline-fonts/raw/master/DroidSansMono/Droid Sans Mono for Powerline.otf"
sudo fc-cache -f
```

Change your terminal (XFCE, Gnome) font to the Droid Sans Mono for Powerline

Follow powerline-shell setup instructions (i.e. download powerline-shell.py script, change .bashrc)

Close all terminal emulators (and maybe restart X)

Open terminal emulator and you are expected to see invalid characters in powerline-shell promt
