### PR TITLE
Added error redirection to avoid stack traces.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ There are a few optional arguments which can be seen by running `powerline-shell
 Add the following to your `.bashrc`:
 
         function _update_ps1() {
-           export PS1="$(~/powerline-shell.py $?)"
+           export PS1="$(~/powerline-shell.py $? 2> /dev/null)"
         }
 
         export PROMPT_COMMAND="_update_ps1"
@@ -71,7 +71,7 @@ Add the following to your `.bashrc`:
 Add the following to your `.zshrc`:
 
         function powerline_precmd() {
-          export PS1="$(~/powerline-shell.py $? --shell zsh)"
+          export PS1="$(~/powerline-shell.py $? --shell zsh 2> /dev/null)"
         }
 
         function install_powerline_precmd() {
@@ -89,7 +89,7 @@ Add the following to your `.zshrc`:
 Redefine `fish_prompt` in ~/.config/fish/config.fish:
 
         function fish_prompt
-            ~/powerline-shell.py $status --shell bare
+            ~/powerline-shell.py $status --shell bare ^/dev/null
         end
 
 # Customization


### PR DESCRIPTION
![screenshot from 2013-09-15 06 49 36](https://f.cloud.github.com/assets/1577944/1144523/0afb8f18-1da5-11e3-8bed-18414a4685b4.png)

Notice that the stack trace on `CTRL+C` are hidden now, but we can still see the warning generated by `powerline-shell`. So we are good :+1: 
