### PR TITLE
Removed unnecessary \ (Fix ZSH prompt)

### DIFF
--- a/segments/root.py
+++ b/segments/root.py
@@ -1,7 +1,7 @@
 def add_root_indicator_segment():
     root_indicators = {
-        'bash': ' \\$ ',
-        'zsh': ' \\$ ',
+        'bash': ' $ ',
+        'zsh': ' $ ',
         'bare': ' $ ',
     }
     bg = Color.CMD_PASSED_BG


### PR DESCRIPTION
Do we need those \?
Actually my zsh looks like this when I use them: (Notice \$ on ZSH)

![screenshot from 2013-09-16 05 30 11](https://f.cloud.github.com/assets/1577944/1146460/226edc68-1e63-11e3-979d-f5c2a83a88bd.png)

And removing them seems to be causing no issues (either in bash or zsh).
