### PR TITLE
Fix read_only segment fallback to default color scheme. Replicate?

### DIFF
--- a/segments/read_only.py
+++ b/segments/read_only.py
@@ -3,7 +3,10 @@ import os
 def add_read_only_segment():
     cwd = powerline.cwd or os.getenv('PWD')
 
+    READONLY_BG = getattr(Color, 'READONLY_BG', 124)
+    READONLY_FG = getattr(Color, 'READONLY_FG', 254)
+
     if not os.access(cwd, os.W_OK):
-        powerline.append(' %s ' % powerline.lock, Color.READONLY_FG, Color.READONLY_BG)
+        powerline.append(' %s ' % powerline.lock, READONLY_FG, READONLY_BG)
 
 add_read_only_segment()


### PR DESCRIPTION
When a theme does not define colors for read_only segment, the segment will use default values instead of throw errors.

Maybe this should be done to all segments? Themes will look much cleaner since all segments would have default colors and there is no need to redeclare these colors inside themes if default value is desired. Only the properties to be overridden would be declared.

@milkbikis @SaswatPadhi
