### PR TITLE
Themes fall back to default.py for missing segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A [Powerline](https://github.com/Lokaltog/vim-powerline) like prompt for Bash, Z
 
 This script uses ANSI color codes to display colors in a terminal. These are
 notoriously non-portable, so may not work for you out of the box, but try 
-setting your $TERM to xterm-256color, because that works for me.
+setting your $TERM to `xterm-256color`, because that works for me.
 
 * Patch the font you use for your terminal: see https://github.com/Lokaltog/powerline-fonts
 
@@ -114,10 +114,15 @@ Make sure that your script does not introduce new globals which might conflict
 with other scripts. Your script should fail silently and run quickly in any
 scenario.
 
+Make sure you introduce new default colors in `themes/default.py` for every new
+segment you create. Test your segment with this theme first.
+
 ### Themes
 
 The `themes` directory stores themes for your prompt, which are basically color
-values used by segments. Create a new theme by copying `themes/default.py` and
+values used by segments. The `default.py` defines a default theme which can be
+used standalone, and every other theme falls back to it if they miss colors for
+any segments. Create new themes by copying any other existing theme and
 changing the values. To use a theme, set the `THEME` variable in `config.py` to
 the name of your theme.
 

--- a/install.py
+++ b/install.py
@@ -24,6 +24,7 @@ def load_source(srcfile):
 
 if __name__ == "__main__":
     source = load_source(TEMPLATE_FILE)
+    source += load_source(os.path.join(THEMES_DIR, 'default.py'))
     source += load_source(os.path.join(THEMES_DIR, config.THEME + '.py'))
     for segment in config.SEGMENTS:
         source += load_source(os.path.join(SEGMENTS_DIR, segment + '.py'))

--- a/themes/basic.py
+++ b/themes/basic.py
@@ -1,6 +1,6 @@
 # Basic theme which only uses colors in 0-15 range
 
-class Color:
+class Color(DefaultColor):
     USERNAME_FG = 8
     USERNAME_BG = 15
 

--- a/themes/default.py
+++ b/themes/default.py
@@ -1,4 +1,8 @@
-class Color:
+class DefaultColor:
+    """
+    This class should have the default colors for every segment.
+    Please test every new segment with this theme first.
+    """
     USERNAME_FG = 250
     USERNAME_BG = 240
 
@@ -34,3 +38,10 @@ class Color:
 
     VIRTUAL_ENV_BG = 35  # a mid-tone green
     VIRTUAL_ENV_FG = 00
+
+class Color(DefaultColor):
+    """
+    This subclass is required when the user chooses to use 'default' theme.
+    Because the segments require a 'Color' class for every theme.
+    """
+    pass

--- a/themes/solarized-dark.py
+++ b/themes/solarized-dark.py
@@ -1,4 +1,4 @@
-class Color:
+class Color(DefaultColor):
     USERNAME_FG = 15
     USERNAME_BG = 4
 


### PR DESCRIPTION
A cleaner way to implement default colors for themes.
This way, the segment code stays away from the theme code.

@marcioAlmada
