### PR TITLE
Fixed jobs count for current shell

### DIFF
--- a/segments/jobs.py
+++ b/segments/jobs.py
@@ -3,9 +3,9 @@ import re
 import subprocess
 
 def add_jobs_segment():
-    ppid = os.getppid()
+    pppid = subprocess.Popen(['ps', '-p', str(os.getppid()), '-oppid='], stdout=subprocess.PIPE).communicate()[0].strip()
     output = subprocess.Popen(['ps', '-a', '-o', 'ppid'], stdout=subprocess.PIPE).communicate()[0]
-    num_jobs = len(re.findall(str(ppid), output)) - 1
+    num_jobs = len(re.findall(str(pppid), output)) - 1
 
     if num_jobs > 0:
         powerline.append(' %d ' % num_jobs, Color.JOBS_FG, Color.JOBS_BG)


### PR DESCRIPTION
The jobs_segment had a major bug. It was always showing me 0 jobs!

It was checking for processes with PPID same as the Python script's PPID.
But actually their grand-parents would be same:

  We generate the entire prompt by evaluating the python script
  in a $() which creates a separate sub-process which is the parent of
  the Python process. The original shell is the parent of the $()
  sub-process. So, we need to get the grand parent id.
