### PR TITLE
Add a simple segment displaying the exit status if non-zero

### DIFF
--- a/config.py.dist
+++ b/config.py.dist
@@ -45,6 +45,9 @@ SEGMENTS = [
 # Shows a '#' if the current user is root, '$' otherwise
 # Also, changes color if the last command exited with a non-zero error code
     'root',
+
+# Show exit code with color if the last command exited with a non-zero value
+    'exit',
 ]
 
 # Change the colors used to draw individual segments in your prompt

--- a/segments/exit.py
+++ b/segments/exit.py
@@ -1,0 +1,13 @@
+def add_exit_indicator_segment():
+    exit_code = powerline.args.prev_error
+
+    if not exit_code:
+        return
+
+    fg = Color.CMD_FAILED_FG
+    bg = Color.CMD_FAILED_BG
+
+    indicator = " {} ".format(exit_code)
+    powerline.append(indicator, fg, bg)
+
+add_exit_indicator_segment()


### PR DESCRIPTION
Basic segment, pretty similar to the root one. I needed it because the root segment doesn't show the exact error code and is always displayed.
