### PR TITLE
Use LANG='C' to prevent language specific git output.

### DIFF
--- a/segments/git.py
+++ b/segments/git.py
@@ -6,7 +6,7 @@ def get_git_status():
     has_untracked_files = False
     origin_position = ""
     output = subprocess.Popen(['git', 'status', '--ignore-submodules'],
-                              stdout=subprocess.PIPE).communicate()[0]
+            env={"LANG": "C"}, stdout=subprocess.PIPE).communicate()[0]
     for line in output.split('\n'):
         origin_status = re.findall(
             r"Your branch is (ahead|behind).*?(\d+) comm", line)


### PR DESCRIPTION
We must be sure we are able to parse the git status output. If we don't use this
while calling popen we will get language specific output that we couldn't parse.
