### PR TITLE
Show username segment in red if the current user is root

### DIFF
--- a/segments/username.py
+++ b/segments/username.py
@@ -8,6 +8,11 @@ def add_username_segment():
         import os
         user_prompt = ' %s ' % os.getenv('USER')
 
-    powerline.append(user_prompt, Color.USERNAME_FG, Color.USERNAME_BG)
+    if os.getenv('USER') == 'root':
+        bgcolor = Color.USERNAME_ROOT_BG
+    else:
+        bgcolor = Color.USERNAME_BG
+
+    powerline.append(user_prompt, Color.USERNAME_FG, bgcolor)
 
 add_username_segment()

--- a/themes/basic.py
+++ b/themes/basic.py
@@ -3,6 +3,7 @@
 class Color(DefaultColor):
     USERNAME_FG = 8
     USERNAME_BG = 15
+    USERNAME_ROOT_BG = 1
 
     HOSTNAME_FG = 8
     HOSTNAME_BG = 7

--- a/themes/default.py
+++ b/themes/default.py
@@ -5,6 +5,7 @@ class DefaultColor:
     """
     USERNAME_FG = 250
     USERNAME_BG = 240
+    USERNAME_ROOT_BG = 124
 
     HOSTNAME_FG = 250
     HOSTNAME_BG = 238

--- a/themes/solarized-dark.py
+++ b/themes/solarized-dark.py
@@ -1,6 +1,7 @@
 class Color(DefaultColor):
     USERNAME_FG = 15
     USERNAME_BG = 4
+    USERNAME_ROOT_BG = 1
 
     HOSTNAME_FG = 15
     HOSTNAME_BG = 10

--- a/themes/washed.py
+++ b/themes/washed.py
@@ -1,6 +1,7 @@
 class Color(DefaultColor):
     USERNAME_FG = 8
     USERNAME_BG = 251
+    USERNAME_ROOT_BG = 209
 
     HOSTNAME_FG = 8
     HOSTNAME_BG = 7


### PR DESCRIPTION
A little visual reminder that the current shell is a root shell. I sometimes forget about this after I didn't touch a root shell for some time, so I'm finding this patch extremely helpful.
