### PR TITLE
move import os just below the func def

### DIFF
--- a/segments/username.py
+++ b/segments/username.py
@@ -1,11 +1,11 @@
 
 def add_username_segment():
+    import os
     if powerline.args.shell == 'bash':
         user_prompt = ' \\u '
     elif powerline.args.shell == 'zsh':
         user_prompt = ' %n '
     else:
-        import os
         user_prompt = ' %s ' % os.getenv('USER')
 
     if os.getenv('USER') == 'root':


### PR DESCRIPTION
the 'import os' was missing for os.getenv('USER'). Was giving me an error.

![bug](https://f.cloud.github.com/assets/227817/2073657/3a3d49ea-8d64-11e3-87ee-31a12b1d6f3a.png)

Hence moved 'import os' up below func def.
