### PR TITLE
git subprocess now gets a patched default env

### DIFF
--- a/segments/git.py
+++ b/segments/git.py
@@ -9,7 +9,7 @@ def get_PATH():
     return os.getenv("PATH")
 
 def git_subprocess_env():
-    return {
+    return dict(os.environ).update({
         # LANG is specified to ensure git always uses a language we are expecting.
         # Otherwise we may be unable to parse the output.
         "LANG": "C",
@@ -19,7 +19,7 @@ def git_subprocess_env():
 
         # https://github.com/milkbikis/powerline-shell/pull/153
         "PATH": get_PATH(),
-    }
+    })
 
 
 def parse_git_branch_info(status):

--- a/segments/git.py
+++ b/segments/git.py
@@ -2,23 +2,11 @@ import re
 import subprocess
 import os
 
-def get_PATH():
-    """Normally gets the PATH from the OS. This function exists to enable
-    easily mocking the PATH in tests.
-    """
-    return os.getenv("PATH")
-
 def git_subprocess_env():
     return dict(os.environ).update({
         # LANG is specified to ensure git always uses a language we are expecting.
         # Otherwise we may be unable to parse the output.
         "LANG": "C",
-
-        # https://github.com/milkbikis/powerline-shell/pull/126
-        "HOME": os.getenv("HOME"),
-
-        # https://github.com/milkbikis/powerline-shell/pull/153
-        "PATH": get_PATH(),
     })
 
 


### PR DESCRIPTION
On environments like Termux, the env variable LD_LIBRARY_PATH must be set in order for git to find libiconv.so. This fixes the git_subprocess_env so that it returns a patched version of the system's env, thus containing LD_LIBRARY_PATH and possibly other nessesary paths for other systems. 
