### PR TITLE
Fixes cwd on windows

### DIFF
--- a/segments/cwd.py
+++ b/segments/cwd.py
@@ -50,7 +50,7 @@ def add_cwd_segment(powerline):
     if not py3:
         cwd = cwd.decode("utf-8")
     if os.name == 'nt':
-        cwd = cwd.replace("/", "\\")
+        cwd = cwd.replace("/", os.sep)
     cwd = replace_home_dir(cwd)
 
     if powerline.args.cwd_mode == 'plain':

--- a/segments/cwd.py
+++ b/segments/cwd.py
@@ -49,6 +49,8 @@ def add_cwd_segment(powerline):
     cwd = powerline.cwd or os.getenv('PWD')
     if not py3:
         cwd = cwd.decode("utf-8")
+    if os.name == 'nt':
+        cwd = cwd.replace("/", "\\")
     cwd = replace_home_dir(cwd)
 
     if powerline.args.cwd_mode == 'plain':


### PR DESCRIPTION
minTTY or other bash consoles might report cwd with forward slashes, these are now replaced with `os.sep` if the platform is reported as nt.
