### PR TITLE
VCS symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,18 +42,20 @@ quick look into the state of your repo:
   of commits is shown along with `⇡` or `⇣` indicating whether a git push
   or pull is pending
 
-In addition, git has a few extra symbols:
+If files are modified or in conflict, the situation is summarized with the
+following symbols:
 
-- `✎` -- a file has been modified, but not staged for commit
-- `✔` -- a file is staged for commit
+- `✎` -- a file has been modified (but not staged for commit, in git)
+- `✔` -- a file is staged for commit (git) or added for tracking
 - `✼` -- a file has conflicts
-
-FIXME
-
-- A `+` appears when untracked files are present (except for git, which uses
-  `?` instead)
+- `❓` -- a file is untracked
 
 Each of these will have a number next to it if more than one file matches.
+
+The segment can start with a symbol representing the version control system in
+use. To show that symbol, the configuration file must have a variable `vcs`
+with an option `show_symbol` set to `true` (see
+[Segment Configuration](#segment-configuration)).
 
 ## Setup
 
@@ -215,7 +217,7 @@ settings.
 
 Some segments support additional configuration. The options for the segment are
 nested under the name of the segment itself. For example, all of the options
-for the `cwd` segment are set in `~/.powerline-shell.py` like:
+for the `cwd` segment are set in `~/.powerline-shell.json` like:
 
 ```
 {
@@ -223,13 +225,17 @@ for the `cwd` segment are set in `~/.powerline-shell.py` like:
     "cwd": {
         options go here
     }
+    "theme": "theme-name",
+    "vcs": {
+        options go here
+    }
 }
 ```
 
 The options for the `cwd` segment are:
 
-- `mode`: If "plain" then simple text will be used to show the cwd. If
-  "dironly," only the current directory will be shown. Otherwise expands the
+- `mode`: If `plain`, then simple text will be used to show the cwd. If
+  `dironly`, only the current directory will be shown. Otherwise expands the
   cwd into individual directories.
 - `max_depth`: Maximum number of directories to show in path
 - `max_dir_size`: Maximum number of characters displayed for each directory in
@@ -239,6 +245,12 @@ The `hostname` segment provides one option:
 
 - `colorize`: If true, the hostname will be colorized based on a hash of
   itself.
+
+The `vcs` variable has one option:
+
+- `show_symbol`: If `true`, the version control system segment will start with
+  a symbol representing the specific version control system in use in the
+  current directory.
 
 ### Contributing new types of segments
 

--- a/powerline_shell/segments/bzr.py
+++ b/powerline_shell/segments/bzr.py
@@ -73,6 +73,9 @@ class Segment(ThreadedSegment):
         if self.stats.dirty:
             bg = self.powerline.theme.REPO_DIRTY_BG
             fg = self.powerline.theme.REPO_DIRTY_FG
-
-        self.powerline.append(" " + self.branch + " ", fg, bg)
+        if self.powerline.segment_conf("vcs", "show_symbol"):
+            symbol = RepoStats().symbols["bzr"] + " "
+        else:
+            symbol = ""
+        self.powerline.append(" " + symbol + self.branch + " ", fg, bg)
         self.stats.add_to_powerline(self.powerline)

--- a/powerline_shell/segments/fossil.py
+++ b/powerline_shell/segments/fossil.py
@@ -74,6 +74,9 @@ class Segment(ThreadedSegment):
         if self.stats.dirty:
             bg = self.powerline.theme.REPO_DIRTY_BG
             fg = self.powerline.theme.REPO_DIRTY_FG
-
-        self.powerline.append(" " + self.branch + " ", fg, bg)
+        if self.powerline.segment_conf("vcs", "show_symbol"):
+            symbol = RepoStats().symbols["fossil"] + " "
+        else:
+            symbol = ""
+        self.powerline.append(" " + symbol + self.branch + " ", fg, bg)
         self.stats.add_to_powerline(self.powerline)

--- a/powerline_shell/segments/git.py
+++ b/powerline_shell/segments/git.py
@@ -98,6 +98,9 @@ class Segment(ThreadedSegment):
         if self.stats.dirty:
             bg = self.powerline.theme.REPO_DIRTY_BG
             fg = self.powerline.theme.REPO_DIRTY_FG
-
-        self.powerline.append(" " + self.branch + " ", fg, bg)
+        if self.powerline.segment_conf("vcs", "show_symbol"):
+            symbol = RepoStats().symbols["git"] + " "
+        else:
+            symbol = ""
+        self.powerline.append(" " + symbol + self.branch + " ", fg, bg)
         self.stats.add_to_powerline(self.powerline)

--- a/powerline_shell/segments/hg.py
+++ b/powerline_shell/segments/hg.py
@@ -72,5 +72,9 @@ class Segment(ThreadedSegment):
         if self.stats.dirty:
             bg = self.powerline.theme.REPO_DIRTY_BG
             fg = self.powerline.theme.REPO_DIRTY_FG
-        self.powerline.append(" " + self.branch + " ", fg, bg)
+        if self.powerline.segment_conf("vcs", "show_symbol"):
+            symbol = RepoStats().symbols["hg"] + " "
+        else:
+            symbol = ""
+        self.powerline.append(" " + symbol + self.branch + " ", fg, bg)
         self.stats.add_to_powerline(self.powerline)

--- a/powerline_shell/segments/svn.py
+++ b/powerline_shell/segments/svn.py
@@ -13,6 +13,16 @@ def svn_subprocess_env():
     return {"PATH": get_PATH()}
 
 
+def _get_svn_branch():
+    p = subprocess.Popen(["svn", "info"],
+                         stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE,
+                         env=svn_subprocess_env())
+    working_dir_root_path = p.communicate()[0].decode("utf-8").splitlines()[1]
+    branch = os.path.basename(working_dir_root_path.split()[-1])
+    return branch
+
+
 def parse_svn_stats(status):
     stats = RepoStats()
     for line in status:
@@ -41,15 +51,16 @@ def build_stats():
         return None
     pdata = p.communicate()
     if p.returncode != 0 or pdata[1][:22] == b'svn: warning: W155007:':
-        return None
+        return None, None
     status = _get_svn_status(pdata)
     stats = parse_svn_stats(status)
-    return stats
+    branch = _get_svn_branch()
+    return stats, branch
 
 
 class Segment(ThreadedSegment):
     def run(self):
-        self.stats = build_stats()
+        self.stats, self.branch = build_stats()
 
     def add_to_powerline(self):
         self.join()
@@ -61,8 +72,8 @@ class Segment(ThreadedSegment):
             bg = self.powerline.theme.REPO_DIRTY_BG
             fg = self.powerline.theme.REPO_DIRTY_FG
         if self.powerline.segment_conf("vcs", "show_symbol"):
-            symbol = RepoStats().symbols["svn"]
+            symbol = RepoStats().symbols["svn"] + " "
         else:
-            symbol = "svn"
-        self.powerline.append(" " + symbol + " ", fg, bg)
+            symbol = ""
+        self.powerline.append(" " + symbol + self.branch + " ", fg, bg)
         self.stats.add_to_powerline(self.powerline)

--- a/powerline_shell/utils.py
+++ b/powerline_shell/utils.py
@@ -19,8 +19,8 @@ class RepoStats(object):
         'conflicted': u'\u273C',
         'git': u'\uE0A0',
         'hg': u'\u263F',
-        'bzr': u'\u25C8',
-        'fossil': u'\u24BB',  # or 24D5, for lowercase 'f'
+        'bzr': u'\u2B61\u20DF',
+        'fossil': u'\u2332',
         'svn': u'\u2446'
     }
 

--- a/powerline_shell/utils.py
+++ b/powerline_shell/utils.py
@@ -16,7 +16,12 @@ class RepoStats(object):
         'staged': u'\u2714',
         'changed': u'\u270E',
         'new': u'\u2753',
-        'conflicted': u'\u273C'
+        'conflicted': u'\u273C',
+        'git': u'\uE0A0',
+        'hg': u'\u263F',
+        'bzr': u'\u25C8',
+        'fossil': u'\u24BB',  # or 24D5, for lowercase 'f'
+        'svn': u'\u2446'
     }
 
     def __init__(self, ahead=0, behind=0, new=0, changed=0, staged=0, conflicted=0):


### PR DESCRIPTION
Taking on @mislam's PR #170, I adapted it to the current state of the VCS' segments.

In the meanwhile I've noticed that the svn segment wasn't working properly and was implemented as a basic segment, so I decided to reimplement it as a threaded one. I should have used a separate branch for this but figured that it wouldn't be worth the trouble. I'll probably implement the svn tests later on, though, and for that I'll use a separate branch + PR, of course.