### PR TITLE
Real Virtual env name while using "pipenv"

### DIFF
--- a/powerline_shell/segments/virtual_env.py
+++ b/powerline_shell/segments/virtual_env.py
@@ -7,6 +7,9 @@ class Segment(BasicSegment):
         env = os.getenv('VIRTUAL_ENV') \
             or os.getenv('CONDA_ENV_PATH') \
             or os.getenv('CONDA_DEFAULT_ENV')
+        if os.getenv('VIRTUAL_ENV') \
+            and os.path.basename(env) == '.venv':
+            env = os.path.basename(os.path.dirname(env))
         if not env:
             return
         env_name = os.path.basename(env)


### PR DESCRIPTION
pipenv is an officially recomended tool for managing python packages
dependencies.
In pipenv we have an option to create virtual env inside the project it
self.
The created virutal env name is .venv.
    
The normal bash display the name of the virual env as the parent folder
name.
Ex: new_shell/.venv then the virual env name displayed in base is
new_shell.
    
In powerline_shell the virtual env name is displayed as .venv.
    
This PR is a fix for displaying the parent folder as virtual env name