### PR TITLE
my idea on how a generic segment would work

### DIFF
--- a/powerline_shell/__init__.py
+++ b/powerline_shell/__init__.py
@@ -154,6 +154,19 @@ DEFAULT_CONFIG = {
 }
 
 
+def parseInlineSegment(dict):
+    ret = None
+    if dict is not None:
+        type = ""
+        if "type" in dict:
+            type = dict["type"]
+        if "options" in dict:
+            opt = dict["options"]
+            if "command" in opt:
+                cmd = opt["command"]
+                ret = {"type":type, "options":{"command":cmd}}
+    return ret
+
 def main():
     arg_parser = argparse.ArgumentParser()
     arg_parser.add_argument('--generate-config', action='store_true',
@@ -183,8 +196,19 @@ def main():
     powerline = Powerline(args, config, theme)
     segments = []
     for seg_name in config["segments"]:
-        mod = importlib.import_module("powerline_shell.segments." + seg_name)
-        segment = getattr(mod, "Segment")(powerline)
+        segment = None
+        if seg_name is None or len(seg_name)<1:
+            continue                            #ignore bad configs
+        elif type(seg_name) is dict:
+            ret = parseInlineSegment(seg_name)
+            if ret is None:
+                continue                        #ignore bad configs
+            else:
+                mod = importlib.import_module("powerline_shell.segments.inline")
+                segment = getattr(mod, "Segment")(powerline, ret)
+        elif type(seg_name) is str:
+            mod = importlib.import_module("powerline_shell.segments." + seg_name)
+            segment = getattr(mod, "Segment")(powerline)
         segment.start()
         segments.append(segment)
     for segment in segments:

--- a/powerline_shell/segments/inline.py
+++ b/powerline_shell/segments/inline.py
@@ -1,0 +1,28 @@
+import os
+import re
+import subprocess
+import platform
+from ..utils import ThreadedSegment
+
+class Segment(ThreadedSegment):
+    '''
+    @author thomas.cherry@gmail.com
+    '''
+    def __init__(self, powerline, config):
+        super(Segment, self).__init__(powerline)
+        self.config = config
+        self.output = None
+
+    def run(self):
+        opt = self.config["options"]
+        cmd = opt["command"]
+        if len(cmd)>0 and len(cmd[0])>0:
+            self.output = subprocess.check_output(cmd).decode('utf-8').strip()
+        
+    def add_to_powerline(self):
+        self.join()
+        if  self.output is not None and len(self.output) > 0:
+            text = ' %s ' % self.output
+            fg_color = self.powerline.theme.CWD_FG      #just use CWD's colors
+            bg_color = self.powerline.theme.PATH_BG     #just use CWD's colors
+            self.powerline.append(text, fg_color, bg_color)


### PR DESCRIPTION
This pull request was inspired by a comment in https://github.com/banga/powerline-shell/pull/319

Here I have created a generic segment called "inline" which handles segments defined as a configuration in the config file. You can have multiples using different commands. The configuration here was provided in the comment from the pull request mentioned above and is not my layout.

Sample configuration in the segments array:

   {
            "type": "stdout",
            "options":{"command": ["hostname", "-f"]}
    }