### PR TITLE
Adds MINGW condition to job count

### DIFF
--- a/powerline_shell/segments/jobs.py
+++ b/powerline_shell/segments/jobs.py
@@ -14,6 +14,12 @@ class Segment(ThreadedSegment):
             output = map(lambda l: int(l.split()[2].strip()),
                 output_proc.communicate()[0].decode("utf-8").splitlines()[1:])
             self.num_jobs = output.count(os.getppid()) - 1
+        elif platform.system().startswith('MINGW'):
+            # mingw ps is too
+            output_proc = subprocess.Popen(['ps', '-af'], stdout=subprocess.PIPE)
+            output = map(lambda l: int(l.split()[2].strip()),
+                output_proc.communicate()[0].decode("utf-8").splitlines()[1:])
+            self.num_jobs = list(output).count(os.getppid()) - 1
         else:
             pppid_proc = subprocess.Popen(['ps', '-p', str(os.getppid()), '-oppid='],
                                           stdout=subprocess.PIPE)


### PR DESCRIPTION
This also contains the `list()` change for this condition. I'm not super familiar with python, but I think that's [a thing that changed in 3](https://stackoverflow.com/questions/33198916/getting-attribute-error-map-object-has-no-attribute-sort), but I'm not sure what the intended version of python is here.

Thanks!