### PR TITLE
Added seperate variables for customizing colors for time segment

### DIFF
--- a/powerline_shell/segments/time.py
+++ b/powerline_shell/segments/time.py
@@ -13,5 +13,5 @@ class Segment(BasicSegment):
         else:
             time_ = ' %s ' % time.strftime('%H:%M:%S')
         powerline.append(time_,
-                         powerline.theme.HOSTNAME_FG,
-                         powerline.theme.HOSTNAME_BG)
+                         powerline.theme.TIME_FG,
+                         powerline.theme.TIME_BG)

--- a/powerline_shell/themes/default.py
+++ b/powerline_shell/themes/default.py
@@ -69,6 +69,9 @@ class DefaultColor(object):
     AWS_PROFILE_FG = 39
     AWS_PROFILE_BG = 238
 
+    TIME_FG = 250
+    TIME_BG = 238
+
 class Color(DefaultColor):
     """
     This subclass is required when the user chooses to use 'default' theme.


### PR DESCRIPTION
Current time segment uses `HOSTNAME_BG`, and `HOSTNAME_FG` variables. 
 - Updated it to use new `TIME_BG` and `TIME_FG` variables.
 - Sets default colors for the new variables.