### PR TITLE
Fix hostname colorize

### DIFF
--- a/powerline_shell/color_compliment.py
+++ b/powerline_shell/color_compliment.py
@@ -10,20 +10,21 @@ from .utils import py3
 
 
 def getOppositeColor(r,g,b):
-    hls = rgb_to_hls(r,g,b)
-    opp = list(hls[:])
-    opp[0] = (opp[0]+0.2)%1 # shift hue (a.k.a. color)
-    if opp[1] > 255/2:   # for level you want to make sure they
-        opp[1] -= 255/2  # are quite different so easily readable
-    else:
-        opp[1] += 255/2
-    if opp[2] > -0.5: # if saturation is low on first color increase second's
-        opp[2] -= 0.5
-    opp = hls_to_rgb(*opp)
-    m = max(opp)
-    if m > 255: #colorsys module doesn't give caps to their conversions
-        opp = [ x*254/m for x in opp]
-    return tuple([ int(x) for x in opp])
+        r, g, b = [x/255.0 for x in r, g, b] # convert to float before getting hls value
+        hls = rgb_to_hls(r,g,b)
+        opp = list(hls[:])
+        opp[0] = (opp[0]+0.2)%1 # shift hue (a.k.a. color)
+        if opp[1] > 255/2:   # for level you want to make sure they
+            opp[1] -= 255/2  # are quite different so easily readable
+        else:
+            opp[1] += 255/2
+        if opp[2] > -0.5: # if saturation is low on first color increase second's
+            opp[2] -= 0.5
+        opp = hls_to_rgb(*opp)
+        m = max(opp)
+        if m > 255: #colorsys module doesn't give caps to their conversions
+            opp = [ x*254/m for x in opp]
+        return tuple([ int(x) for x in opp])
 
 def stringToHashToColorAndOpposite(string):
     if py3:

--- a/powerline_shell/color_compliment.py
+++ b/powerline_shell/color_compliment.py
@@ -10,21 +10,21 @@ from .utils import py3
 
 
 def getOppositeColor(r,g,b):
-        r, g, b = [x/255.0 for x in r, g, b] # convert to float before getting hls value
-        hls = rgb_to_hls(r,g,b)
-        opp = list(hls[:])
-        opp[0] = (opp[0]+0.2)%1 # shift hue (a.k.a. color)
-        if opp[1] > 255/2:   # for level you want to make sure they
-            opp[1] -= 255/2  # are quite different so easily readable
-        else:
-            opp[1] += 255/2
-        if opp[2] > -0.5: # if saturation is low on first color increase second's
-            opp[2] -= 0.5
-        opp = hls_to_rgb(*opp)
-        m = max(opp)
-        if m > 255: #colorsys module doesn't give caps to their conversions
-            opp = [ x*254/m for x in opp]
-        return tuple([ int(x) for x in opp])
+    r, g, b = [x/255.0 for x in r, g, b] # convert to float before getting hls value
+    hls = rgb_to_hls(r,g,b)
+    opp = list(hls[:])
+    opp[0] = (opp[0]+0.2)%1 # shift hue (a.k.a. color)
+    if opp[1] > 255/2:   # for level you want to make sure they
+        opp[1] -= 255/2  # are quite different so easily readable
+    else:
+        opp[1] += 255/2
+    if opp[2] > -0.5: # if saturation is low on first color increase second's
+        opp[2] -= 0.5
+    opp = hls_to_rgb(*opp)
+    m = max(opp)
+    if m > 255: #colorsys module doesn't give caps to their conversions
+        opp = [ x*254/m for x in opp]
+    return tuple([ int(x) for x in opp])
 
 def stringToHashToColorAndOpposite(string):
     if py3:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 nose>=1.3.7
 mock>=1.3.0
 sh>=1.11
+parameterized>=0.6.1

--- a/test/color_compliment_test.py
+++ b/test/color_compliment_test.py
@@ -1,0 +1,49 @@
+import unittest
+from parameterized import parameterized
+
+from powerline_shell.color_compliment import getOppositeColor
+
+
+def build_inputs():
+    
+    # Build 768 hex/rgb values to test against getOppositeColor
+    input_bytes = map(hex, xrange(pow(2,8)))
+
+    input_list = []
+    for x in input_bytes:
+
+        #Building hex range of [00-ff]:00:00
+        combined1 = hex((int(x,16)<<16)| ((int(input_bytes[0],16)<<8)|int(input_bytes[0],16))) 
+        test_input1 = tuple((int(x,16), int(input_bytes[0],16), int(input_bytes[0],16)))
+
+        #Building hex range of 00:[00-ff]:00
+        combined2 = hex((int(input_bytes[0],16)<<16)| ((int(x,16)<<8)|int(input_bytes[0],16)))
+        test_input2 = tuple((int(input_bytes[0],16), int(x,16), int(input_bytes[0],16))) 
+
+        #Building hex range of 00:00:[00-ff]
+        combined3 = hex((int(input_bytes[0],16)<<16)| ((int(input_bytes[0],16)<<8)|int(x,16)))
+        test_input3 = tuple((int(input_bytes[0],16), int(input_bytes[0],16), int(x,16))) 
+
+        input_list.append(tuple((combined1, test_input1)))
+        input_list.append(tuple((combined2, test_input2)))
+        input_list.append(tuple((combined3, test_input3)))
+
+    return input_list
+
+class getOppositeColorTestCase(unittest.TestCase):
+
+    '''
+    Test only runs against 768 combinations of rgb values. 
+    Trying to run parameterized unittest against 16.77M rgb values
+    was near impossible (need lots of memory and time).  Of the 768 
+    values tested, the test has proven to catch 192 exceptions (and 3
+    ZeroDivisionError exceptions from rgb_to_hls).  This can be tested
+    by commenting out the first line of getOppositeColor, which 
+    converts the rgb values to float.
+    '''
+
+    @parameterized.expand(build_inputs)
+ 
+    def test_rgb_input_get_opposite_not_negative(self, name, test_input):
+        negative = -1
+        self.assertNotIn(negative, getOppositeColor(*test_input), u'{0:#08x} returns negative number in rgb tuple'.format(int(name,16)))


### PR DESCRIPTION
@b-ryan 

This PR fixes issue #353 and adds a unittest.  The fix is adding one line to `getOppositeColor` which needs to convert the rgb values to float before sending to `rgb_to_hls`.   [This stackoverflow](https://stackoverflow.com/questions/15442285/converting-rgb-to-hls-and-back) article helped narrow down the solution.  

This issue only occurred on hostnames that happened to hash to a value in ranges that would be computed incorrectly by `rgb_to_hls`.  In most instances the returned opposite values from `getOppositeColor` would be a **-1** in the r,g, or b position.  The unittest added also caught, although is not asserting,  **ZeroDivisionError** exceptions that occurred in `rgb_to_hls`.

```
======================================================================
ERROR: test_rgb_input_get_opposite_not_negative_2_0x20000 (color_compliment_test.getOppositeColorTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/me/.pyenvs/powerline-dev/lib/python2.7/site-packages/parameterized/parameterized.py", line 392, in standalone_func
    return func(*(a + p.args), **p.kwargs)
  File "/Users/me/repos/src/github.com/comagnaw/powerline-shell/test/color_compliment_test.py", line 42, in test_rgb_input_get_opposite_not_negative
    self.assertNotIn(negative, getOppositeColor(*test_input), u'{0:#08x} returns negative number in rgb tuple'.format(int(name,16)))
  File "/Users/me/repos/src/github.com/comagnaw/powerline-shell/powerline_shell/color_compliment.py", line 16, in getOppositeColor
    hls = rgb_to_hls(r,g,b)
  File "/usr/local/Cellar/python/2.7.14_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/colorsys.py", line 77, in rgb_to_hls
    s = (maxc-minc) / (2.0-maxc-minc)
ZeroDivisionError: float division by zero

```

Unfortunately, the unittest could not realistically be written to test 2^24 values that my be computed against a hostname (I tried....but did not have enough memory or patience to even build/run the parameterized tests.  I did run a unittest that was not parameterized and got a successful result against the 2^24 but any failures discovered by that unittest would be hard to narrow down, given it was a one and done unittest...it did take a long time but required little to no memory).  The test is written to test 768 values via parameterized package, which was added to the requirements-dev.txt.   If you uncomment the conversion to float in `getOppositeColor`, you will get 192 assertions and 3 errors.

