### PR TITLE
passwordless root hint

### DIFF
--- a/powerline_shell/segments/sudo.py
+++ b/powerline_shell/segments/sudo.py
@@ -1,0 +1,9 @@
+import os
+from ..utils import BasicSegment
+import subprocess
+
+
+class Segment(BasicSegment):
+    def add_to_powerline(self):
+        if subprocess.Popen(['sudo', '-n', 'echo', '-n', '1'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE).communicate()[0] == b'1':
+            self.powerline.append(" # ", self.powerline.theme.SUDO_FG, self.powerline.theme.SUDO_BG)

--- a/powerline_shell/themes/default.py
+++ b/powerline_shell/themes/default.py
@@ -72,6 +72,9 @@ class DefaultColor(object):
     TIME_FG = 250
     TIME_BG = 238
 
+    SUDO_BG = 196
+    SUDO_FG = 15
+
 class Color(DefaultColor):
     """
     This subclass is required when the user chooses to use 'default' theme.


### PR DESCRIPTION
Shows if terminal could get root access without entering a password. This often happens when you work with `sudo`