### PR TITLE
Fix double-escape of user/root ($/#) indicator (fixes #315)

### DIFF
--- a/powerline_shell/__init__.py
+++ b/powerline_shell/__init__.py
@@ -114,7 +114,9 @@ class Powerline(object):
     def bgcolor(self, code):
         return self.color('48', code)
 
-    def append(self, content, fg, bg, separator=None, separator_fg=None):
+    def append(self, content, fg, bg, separator=None, separator_fg=None, sanitize=True):
+        if self.args.shell == "bash" and sanitize:
+            content = re.sub(r"([`$])", r"\\\1", content)
         self.segments.append((content, fg, bg,
             separator if separator is not None else self.separator,
             separator_fg if separator_fg is not None else bg))
@@ -129,16 +131,12 @@ class Powerline(object):
 
     def draw_segment(self, idx):
         segment = self.segments[idx]
-        if self.args.shell == "bash" and segment[0] != ' \\$ ':
-            sanitized = re.sub(r"([`$])", r"\\\1", segment[0])
-        else:
-            sanitized = segment[0]
         next_segment = self.segments[idx + 1] if idx < len(self.segments)-1 else None
 
         return ''.join((
             self.fgcolor(segment[1]),
             self.bgcolor(segment[2]),
-            sanitized,
+            segment[0],
             self.bgcolor(next_segment[2]) if next_segment else self.reset,
             self.fgcolor(segment[4]),
             segment[3]))

--- a/powerline_shell/__init__.py
+++ b/powerline_shell/__init__.py
@@ -129,7 +129,7 @@ class Powerline(object):
 
     def draw_segment(self, idx):
         segment = self.segments[idx]
-        if self.args.shell == "bash":
+        if self.args.shell == "bash" and segment[0] != ' \\$ ':
             sanitized = re.sub(r"([`$])", r"\\\1", segment[0])
         else:
             sanitized = segment[0]

--- a/powerline_shell/segments/root.py
+++ b/powerline_shell/segments/root.py
@@ -15,4 +15,4 @@ class Segment(BasicSegment):
         if powerline.args.prev_error != 0:
             fg = powerline.theme.CMD_FAILED_FG
             bg = powerline.theme.CMD_FAILED_BG
-        powerline.append(root_indicators[powerline.args.shell], fg, bg)
+        powerline.append(root_indicators[powerline.args.shell], fg, bg, sanitize=False)


### PR DESCRIPTION
If our segment is ' \\$ ' then it is already sanitized and should not be escaped again, so we avoid it.