### PR TITLE
Ruby Segment changes for Python 2/3:

### DIFF
--- a/powerline_shell/segments/ruby_version.py
+++ b/powerline_shell/segments/ruby_version.py
@@ -6,14 +6,17 @@ from ..utils import BasicSegment
 class Segment(BasicSegment):
     def add_to_powerline(self):
         powerline = self.powerline
+
         try:
-            p1 = subprocess.Popen(["ruby", "-v"], stdout=subprocess.PIPE)
-            p2 = subprocess.Popen(["sed", "s/ (.*//"], stdin=p1.stdout, stdout=subprocess.PIPE)
-            version = p2.communicate()[0].decode("utf-8").rstrip()
-            if os.environ.has_key("GEM_HOME"):
-              gem = os.environ["GEM_HOME"].split("@")
-              if len(gem) > 1:
-                version += " " + gem[1]
-            powerline.append(version, 15, 1)
+            p1 = subprocess.Popen(['ruby', '-v'], stdout=subprocess.PIPE)
+            p2 = subprocess.Popen(['sed', "s/ (.*//"], stdin=p1.stdout, stdout=subprocess.PIPE)
+            ruby_and_gemset = p2.communicate()[0].decode('utf-8').rstrip()
+
+            gem_set = os.environ.get('GEM_HOME', '@').split('@')
+
+            if len(gem_set) > 1:
+                ruby_and_gemset += "@{}".format(gem_set.pop())
+
+            powerline.append(ruby_and_gemset, 15, 1)
         except OSError:
             return


### PR DESCRIPTION
- use "GEM_HOME" in keys
- removal of python2 specific code
- verification of python2 / python3 functionality