### PR TITLE
Add the ability to provide custom segments

### DIFF
--- a/powerline_shell/__init__.py
+++ b/powerline_shell/__init__.py
@@ -224,13 +224,22 @@ def main():
             try:
                 spec.loader.exec_module(mod)
                 segment = getattr(mod, "Segment")(powerline)
-            except FileNotFoundError:
+            except (FileNotFoundError, AttributeError):
                 pass
         if not segment:
-            mod = importlib.import_module(mod_name)
-            segment = getattr(mod, "Segment")(powerline)
-        segment.start()
-        segments.append(segment)
+            try:
+                mod = importlib.import_module(mod_name)
+            except ModuleNotFoundError:
+                pass
+            try:
+                segment = getattr(mod, "Segment")(powerline)
+            except AttributeError:
+                pass
+        if segment:
+            segment.start()
+            segments.append(segment)
+        else:
+            warn("Segment not found: {:s}".format(seg_name))
     for segment in segments:
         segment.add_to_powerline()
     sys.stdout.write(powerline.draw())


### PR DESCRIPTION
This adds the ability to provide custom segments in a separate directory which is specified by an environment variable. It is a "works for me" contribution which you can modify further, but I would like to see something like it included in the project. The reason, of course, is that I want to be able to customize the prompt without touching the `pip` installed package.

As a bonus, I added a warning, as opposed to bare Python exceptions, in case a segment is not found, but have no problem taking it out if you don't like it.