### PR TITLE
[FEATURE] Add withHost option for username

### DIFF
--- a/powerline_shell/segments/username.py
+++ b/powerline_shell/segments/username.py
@@ -1,21 +1,28 @@
 from ..utils import BasicSegment
 import os
 import getpass
+from socket import gethostname
 
 
 class Segment(BasicSegment):
     def add_to_powerline(self):
         powerline = self.powerline
-        if powerline.args.shell == "bash":
-            user_prompt = r" \u "
-        elif powerline.args.shell == "zsh":
-            user_prompt = " %n "
+        
+        if powerline.segment_conf("username", "withHost"):
+            hostname = gethostname()
+            user_prompt = " %s@%s " % (os.getenv("USER"),
+                    hostname.split(".")[0])
         else:
-            user_prompt = " %s " % os.getenv("USER")
+            if powerline.args.shell == "bash":
+                user_prompt = r" \u "
+            elif powerline.args.shell == "zsh":
+                user_prompt = " %n "
+            else:
+                user_prompt = " %s " % os.getenv("USER")
 
         if getpass.getuser() == "root":
-            bgcolor = powerline.theme.USERNAME_ROOT_BG
+                bgcolor = powerline.theme.USERNAME_ROOT_BG
         else:
-            bgcolor = powerline.theme.USERNAME_BG
+                bgcolor = powerline.theme.USERNAME_BG           
 
         powerline.append(user_prompt, powerline.theme.USERNAME_FG, bgcolor)


### PR DESCRIPTION
Resolves: #370 

I added a "withHost" option for the username segment which makes the username segment also show the hostname just as in normal POSIX shells, like this: `username@hostname`.

Config option:
```
"username": {
    "withHost": true
}   
```

### Screenshot: 
![2018-03-02_17_39_06](https://user-images.githubusercontent.com/16862997/36910314-a3ce2930-1e40-11e8-8e4c-ec14a4208495.png)
