### PR TITLE
Fix filename for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ python setup.py install
 
 ### Bash
 
-Add the following to your `.bashrc` (or `.profile` on Mac):
+Add the following to your `.bashrc` (or `.bash_profile` on macOS):
 
 ```
 function _update_ps1() {


### PR DESCRIPTION
This pull requests fixes what appears to be an incorrect filename (at least for default setups of macOS, which I have) in the setup text.

Adding the BASH commands found in setup to any combination of .bash_rc or .profile on my Macs (one of which is brand new so it's a default configuration) did not work. Only when I added it to .bash_profile did powerline-shell work as expected.