### PR TITLE
Add proper segment for RVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ are:
 - `read_only` - Shows a lock icon if the current directory is read-only.
 - `root` - Shows a `#` if logged in as root, `$` otherwise.
 - `ruby_version` - `ruby --version`
+- `rvm` - Shows version and gemset from `RUBY_VERSION` and `GEM_HOME` environment vars.
 - `set_term_title` - If able, sets the title of your terminal to include some
   useful info.
 - `ssh` - If logged into over SSH, shows a network icon.

--- a/powerline_shell/segments/rvm.py
+++ b/powerline_shell/segments/rvm.py
@@ -1,0 +1,29 @@
+import os
+from ..utils import BasicSegment
+
+
+class Segment(BasicSegment):
+    def add_to_powerline(self):
+        powerline = self.powerline
+        try:
+            ruby_version = os.environ.get('RUBY_VERSION')
+            gem_home = os.environ.get('GEM_HOME')
+            gem_set = None
+
+            if gem_home:
+                gem_home_parts = gem_home.split('@', 2)
+                if len(gem_home_parts) > 1:
+                    gem_set = gem_home_parts[1]
+
+            # print only when using a defined ruby version
+            # empty when using system ruby
+            if ruby_version:
+                text = ruby_version
+                if gem_set:
+                    text += '@' + gem_set
+
+                powerline.append(' %s ' % text,
+                                 powerline.theme.VIRTUAL_ENV_FG,
+                                 powerline.theme.VIRTUAL_ENV_BG)
+        except OSError:
+            return


### PR DESCRIPTION
This improves the behavior of `ruby_version` for RVM, so it only prints information when a version has been chosen by RVM.