### PR TITLE
Add option to specify powerline shell config file as argument.

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,13 @@ powerline-shell --generate-config > ~/.powerline-shell.json
 (As an example, my config file is located here:
 [here](https://github.com/b-ryan/dotfiles/blob/master/home/powerline-shell.json))
 
+If you want to have multiple config files, tell Powerline-Shell where to look
+with the `--config-file` parameter.
+
+```
+powerline-shell --config-file ~/.powerline-shell-alternative.json
+```
+
 ### Adding, Removing and Re-arranging segments
 
 Once you have generated your config file, you can now start adding or removing

--- a/powerline_shell/__init__.py
+++ b/powerline_shell/__init__.py
@@ -142,10 +142,10 @@ class Powerline(object):
             segment[3]))
 
 
-def find_config():
+def find_config(default_location):
     for location in [
         "powerline-shell.json",
-        "~/.powerline-shell.json",
+        default_location,
         os.path.join(os.environ.get("XDG_CONFIG_HOME", "~/.config"), "powerline-shell", "config.json"),
     ]:
         full = os.path.expanduser(location)
@@ -188,6 +188,8 @@ def main():
     arg_parser = argparse.ArgumentParser()
     arg_parser.add_argument('--generate-config', action='store_true',
                             help='Generate the default config and print it to stdout')
+    arg_parser.add_argument('--config-file', action='store', default='"~/.powerline-shell.json"',
+                            help='Override config location')
     arg_parser.add_argument('--shell', action='store', default='bash',
                             help='Set this to your shell type',
                             choices=['bash', 'tcsh', 'zsh', 'bare'])
@@ -199,7 +201,7 @@ def main():
         print(json.dumps(DEFAULT_CONFIG, indent=2))
         return 0
 
-    config_path = find_config()
+    config_path = find_config(args.config_file)
     if config_path:
         with open(config_path) as f:
             try:

--- a/powerline_shell/__init__.py
+++ b/powerline_shell/__init__.py
@@ -188,7 +188,7 @@ def main():
     arg_parser = argparse.ArgumentParser()
     arg_parser.add_argument('--generate-config', action='store_true',
                             help='Generate the default config and print it to stdout')
-    arg_parser.add_argument('--config-file', action='store', default='"~/.powerline-shell.json"',
+    arg_parser.add_argument('--config-file', action='store', default='~/.powerline-shell.json',
                             help='Override config location')
     arg_parser.add_argument('--shell', action='store', default='bash',
                             help='Set this to your shell type',

--- a/powerline_shell/__init__.py
+++ b/powerline_shell/__init__.py
@@ -142,10 +142,10 @@ class Powerline(object):
             segment[3]))
 
 
-def find_config(default_location):
+def find_config():
     for location in [
         "powerline-shell.json",
-        default_location,
+        "~/.powerline-shell.json",
         os.path.join(os.environ.get("XDG_CONFIG_HOME", "~/.config"), "powerline-shell", "config.json"),
     ]:
         full = os.path.expanduser(location)
@@ -188,8 +188,8 @@ def main():
     arg_parser = argparse.ArgumentParser()
     arg_parser.add_argument('--generate-config', action='store_true',
                             help='Generate the default config and print it to stdout')
-    arg_parser.add_argument('--config-file', action='store', default='~/.powerline-shell.json',
-                            help='Override config location')
+    arg_parser.add_argument('-c', '--config', action='store', default=None,
+                            help='Override default config file location')
     arg_parser.add_argument('--shell', action='store', default='bash',
                             help='Set this to your shell type',
                             choices=['bash', 'tcsh', 'zsh', 'bare'])
@@ -201,7 +201,13 @@ def main():
         print(json.dumps(DEFAULT_CONFIG, indent=2))
         return 0
 
-    config_path = find_config(args.config_file)
+    if args.config_file and not os.path.exists(os.path.expanduser(args.config_file)):
+        print("Cannot find config file: {}".format(args.config_file), file=sys.stderr)
+        return 1
+    elif args.config_file:
+        config_path = args.config_file
+    else:
+        config_path = find_config()
     if config_path:
         with open(config_path) as f:
             try:


### PR DESCRIPTION
This is useful if sometimes, for example inside an IDE, you might want a truncated shell prompt or a different theme to match your IDE colors.

You specify --config-file in the arguments and viola -- it uses a different config file location.

Quick docs mention included in PR.