### PR TITLE
Custom indicators on root segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,19 @@ The options for the `battery` segment are:
 - `always_show_percentage`: If true, show percentage when fully charged on AC.
 - `low_threshold`: Threshold percentage for low-battery indicator color.
 
+The `root` segment provides the option to customize `indicators` on each of the supported shells. For example:
+
+```
+{
+  "root": {
+    "indicators": {
+      "bash": " bash 🤖 ",
+      "zsh": " zsh 🤖 "
+    }
+  }
+}
+```
+
 ### Contributing new types of segments
 
 The `powerline_shell/segments` directory contains python scripts which are

--- a/powerline_shell/segments/root.py
+++ b/powerline_shell/segments/root.py
@@ -4,11 +4,22 @@ from ..utils import BasicSegment
 class Segment(BasicSegment):
     def add_to_powerline(self):
         powerline = self.powerline
+        config = self.powerline.config
+
+        def exists(obj, chain):
+            _key = chain.pop(0)
+            if _key in obj:
+                return exists(obj[_key], chain) if chain else obj[_key]
+
+        def indicators(default, shell, path='root.indicators'):
+            indicator = exists(config, (path + '.' + shell).split('.'))
+            return indicator if indicator else default
+
         root_indicators = {
-            'bash': ' \\$ ',
-            'tcsh': ' %# ',
-            'zsh': ' %# ',
-            'bare': ' $ ',
+            'bash': indicators(' \\$ ', 'bash'),
+            'tcsh': indicators(' %# ', 'tcsh'),
+            'zsh': indicators(' %# ', 'zsh'),
+            'bare': indicators(' $ ', 'bare'),
         }
         bg = powerline.theme.CMD_PASSED_BG
         fg = powerline.theme.CMD_PASSED_FG


### PR DESCRIPTION
Hello, this is a simple pull request for
Enabling custom indicators on root segment.
Thanks in advance.

_preview example:_
![screen shot 2018-05-28 at 23 37 05](https://user-images.githubusercontent.com/3202177/40635375-16518a00-62d0-11e8-9a1e-52dbdefaef2b.png)

