### PR TITLE
Cygwin fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changes
 
-2018-06-21 (version 0.7.0-rc1)
+2018-09-15 (version 0.7.0)
 
 * New generic `stdout` and `env` segments
 

--- a/powerline_shell/segments/jobs.py
+++ b/powerline_shell/segments/jobs.py
@@ -11,8 +11,8 @@ class Segment(ThreadedSegment):
         if platform.system().startswith('CYGWIN'):
             # cygwin ps is a special snowflake...
             output_proc = subprocess.Popen(['ps', '-af'], stdout=subprocess.PIPE)
-            output = map(lambda l: int(l.split()[2].strip()),
-                output_proc.communicate()[0].decode("utf-8").splitlines()[1:])
+            output = list(map(lambda l: int(l.split()[2].strip()),
+                output_proc.communicate()[0].decode("utf-8").splitlines()[1:]))
             self.num_jobs = output.count(os.getppid()) - 1
         else:
             pppid_proc = subprocess.Popen(['ps', '-p', str(os.getppid()), '-oppid='],

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="powerline-shell",
-    version="0.7.0-rc1",
+    version="0.7.0",
     description="A pretty prompt for your shell",
     author="Buck Ryan",
     author_email="buck@buckryan.com",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     author="Buck Ryan",
     author_email="buck@buckryan.com",
     license="MIT",
-    url="https://github.com/banga/powerline-shell",
+    url="https://github.com/b-ryan/powerline-shell",
     classifiers=[
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",


### PR DESCRIPTION
map() now returns iterable not list. I had an exception happening before this fix