### PR TITLE
jobs.py workaround for Windows ps missing -o

### DIFF
--- a/powerline_shell/segments/jobs.py
+++ b/powerline_shell/segments/jobs.py
@@ -2,18 +2,28 @@ import os
 import re
 import subprocess
 import platform
+import sys
+try:
+    from shutil import which
+except ImportError:
+    from distutils.spawn import find_executable as which  # EXE is uppercased
 from ..utils import ThreadedSegment
 
 
 class Segment(ThreadedSegment):
     def run(self):
         self.num_jobs = 0
-        if platform.system().startswith('CYGWIN'):
-            # cygwin ps is a special snowflake...
+        if platform.system().startswith('CYGWIN') or \
+            platform.system().startswith('MSYS') or \
+            (platform.system() == 'Windows' and '\\usr\\bin\ps' in (which('ps') or '')):
+            # cygwin ps (and msys) is a special snowflake...
             output_proc = subprocess.Popen(['ps', '-af'], stdout=subprocess.PIPE)
             output = map(lambda l: int(l.split()[2].strip()),
                 output_proc.communicate()[0].decode("utf-8").splitlines()[1:])
-            self.num_jobs = output.count(os.getppid()) - 1
+            if sys.version_info[0] < 3:
+                self.num_jobs = output.count(os.getppid()) - 1
+            else:
+                self.num_jobs = list(output).count(os.getppid()) - 1
         else:
             pppid_proc = subprocess.Popen(['ps', '-p', str(os.getppid()), '-oppid='],
                                           stdout=subprocess.PIPE)


### PR DESCRIPTION
This is the patch from 442 https://github.com/b-ryan/powerline-shell/issues/422

This has some extra detection in case ps is from Git for Windows
This seems to be the same version, but installed in another location.

Currently untested as I'm having some other issues with powerline shell under MING64/bash/mintty on windows.