### PR TITLE
Added option for POWERLINE_ENV_NAME to override VIRTUAL_ENV

### DIFF
--- a/powerline_shell/segments/virtual_env.py
+++ b/powerline_shell/segments/virtual_env.py
@@ -7,9 +7,14 @@ class Segment(BasicSegment):
         env = os.getenv('VIRTUAL_ENV') \
             or os.getenv('CONDA_ENV_PATH') \
             or os.getenv('CONDA_DEFAULT_ENV')
+        
         if os.getenv('VIRTUAL_ENV') \
             and os.path.basename(env) == '.venv':
             env = os.path.basename(os.path.dirname(env))
+        
+        if os.getenv('POWERLINE_ENV_NAME'):
+            env = os.getenv('POWERLINE_ENV_NAME')
+
         if not env:
             return
         env_name = os.path.basename(env)


### PR DESCRIPTION
Sometimes, the virtualenv name can get really long, and the user may not have a choice to rename it (for example, if they're using pyenv). This pull request allows `POWERLINE_ENV_NAME` to override `VIRTUAL_ENV`, making powerline-shell more space efficient.