### PR TITLE
modified to read symbols from theme

### DIFF
--- a/powerline_shell/__init__.py
+++ b/powerline_shell/__init__.py
@@ -54,27 +54,30 @@ def get_valid_cwd():
     return cwd
 
 
-class Powerline(object):
-    symbols = {
-        'compatible': {
-            'lock': 'RO',
-            'network': 'SSH',
-            'separator': u'\u25B6',
-            'separator_thin': u'\u276F'
-        },
-        'patched': {
+DEFAULT_SYMBOLS = {
+    'compatible': {
+        'lock': 'RO',
+        'network': 'SSH',
+        'separator': u'\u25B6',
+        'separator_thin': u'\u276F'
+    },
+    'patched': {
             'lock': u'\uE0A2',
             'network': 'SSH',
             'separator': u'\uE0B0',
             'separator_thin': u'\uE0B1'
-        },
-        'flat': {
-            'lock': u'\uE0A2',
-            'network': 'SSH',
-            'separator': '',
-            'separator_thin': ''
-        },
+    },
+    'flat': {
+        'lock': u'\uE0A2',
+        'network': 'SSH',
+        'separator': '',
+        'separator_thin': ''
     }
+}
+
+
+class Powerline(object):
+    
 
     color_templates = {
         'bash': r'\[\e%s\]',
@@ -89,12 +92,16 @@ class Powerline(object):
         self.theme = theme
         self.cwd = get_valid_cwd()
         mode = config.get("mode", "patched")
+
+        template_symbols = getattr(theme, 'SYMBOLS', DEFAULT_SYMBOLS)
+        symbols = template_symbols.get(mode, DEFAULT_SYMBOLS.get(mode, DEFAULT_SYMBOLS['patched']))
+
         self.color_template = self.color_templates[args.shell]
         self.reset = self.color_template % '[0m'
-        self.lock = Powerline.symbols[mode]['lock']
-        self.network = Powerline.symbols[mode]['network']
-        self.separator = Powerline.symbols[mode]['separator']
-        self.separator_thin = Powerline.symbols[mode]['separator_thin']
+        self.lock = symbols['lock']
+        self.network = symbols['network']
+        self.separator = symbols['separator']
+        self.separator_thin = symbols['separator_thin']
         self.segments = []
 
     def segment_conf(self, seg_name, key, default=None):


### PR DESCRIPTION
I found that I wanted to be able to customize the separators used by powerline. In order to make this modular, I modified `powerline_shell/__init__.py` to detect and load this information from the theme.

The default symbols are used if the theme does not provide a `SYMBOLS` dictionary itself. Interestingly, this also makes it possible to use different `modes` as defined in the `Color.SYMBOLS` object

For example, a config like this

```
{
  "segments": [
    "virtual_env",
    "username",
    "hostname",
    "ssh",
    "cwd",
    "git",
    "hg",
    "jobs",
    "root"
  ],
  "cwd": {
    "max_depth": 2,
    "full_cwd": true
  },
  "theme": "~/.config/powerline-shell/themes/solarized-flames.py",
  "mode": "flames"
}
```

points to this theme 

```
from powerline_shell.themes.default import DefaultColor


class Color(DefaultColor):
    USERNAME_FG = 15
    USERNAME_BG = 4
    USERNAME_ROOT_BG = 1

    HOSTNAME_FG = 15
    HOSTNAME_BG = 10

    HOME_SPECIAL_DISPLAY = False
    PATH_FG = 7
    PATH_BG = 10
    CWD_FG = 15
    SEPARATOR_FG = 14

    READONLY_BG = 1
    READONLY_FG = 7

    REPO_CLEAN_FG = 14
    REPO_CLEAN_BG = 0
    REPO_DIRTY_FG = 3
    REPO_DIRTY_BG = 0

    JOBS_FG = 4
    JOBS_BG = 8

    CMD_PASSED_FG = 15
    CMD_PASSED_BG = 2
    CMD_FAILED_FG = 15
    CMD_FAILED_BG = 1

    SVN_CHANGES_FG = REPO_DIRTY_FG
    SVN_CHANGES_BG = REPO_DIRTY_BG

    VIRTUAL_ENV_BG = 15
    VIRTUAL_ENV_FG = 2

    AWS_PROFILE_FG = 7
    AWS_PROFILE_BG = 2

    TIME_FG = 15
    TIME_BG = 10
    # https://github.com/ryanoasis/powerline-extra-symbols
    SYMBOLS = {
        "flames": {
            "lock": u"\uE0A2",
            "network": u"\uE0A1",
            "separator": u"\uE0C0 ",
            "separator_thin": u"\uE0b1"
        },
        'patched-blocks': {
            'lock': u'\uE0A2',
            'network': u'\uE0A2',
            'separator': u'\uE0cd',
            'separator_thin': u'\uE0cc'
        }

    }
```

This give me a powerline theme that uses powerline extra symbols.

![flames_powerline](https://user-images.githubusercontent.com/1051091/54456268-5c54ce80-4723-11e9-9bfd-2aef622beeeb.png)
