### PR TITLE
Make battery warning optional

### DIFF
--- a/powerline_shell/segments/battery.py
+++ b/powerline_shell/segments/battery.py
@@ -11,7 +11,8 @@ class Segment(BasicSegment):
         elif os.path.exists("/sys/class/power_supply/BAT1"):
             dir_ = "/sys/class/power_supply/BAT1"
         else:
-            warn("battery directory could not be found")
+            if self.powerline.segment_conf("battery", "directory_warning", True):
+                warn("battery directory could not be found")
             return
 
         with open(os.path.join(dir_, "capacity")) as f:


### PR DESCRIPTION
This PR makes the "battery directory could not be found" warning optional, for the case in which the user shares dotfiles between computers, some of which have batteries and some of which do not. One can configure it via:

```json
"battery":
  "directory_warning": false
}
```

The existing behavior remains the default.