### PR TITLE
Beat Time segment

### DIFF
--- a/powerline_shell/segments/beat.py
+++ b/powerline_shell/segments/beat.py
@@ -1,0 +1,46 @@
+import math
+import datetime
+from ..utils import BasicSegment
+
+class Segment(BasicSegment):
+    def add_to_powerline(self):
+        '''
+        Interface method called by Powerline
+        '''
+        pline = self.powerline
+        beat = self.current_beat()
+        format = "%05.1f" if self.show_decimal() else "%03.0f"
+        if self.show_at_sign():
+            format = "@%s" % format
+        pline.append(format % beat, pline.theme.TIME_FG, pline.theme.TIME_BG)
+    def show_decimal(self):
+        '''
+        @return boolean
+        '''
+        raw = self.powerline.segment_conf("beat", "show_decimal", "True")
+        return raw != "False"
+    def show_at_sign(self):
+        '''
+        @return boolean
+        '''
+        raw = self.powerline.segment_conf("beat", "show_at_sign", "True")
+        return raw != "False"
+    def current_datetime(self):
+        '''
+        Don't do anything in this function but get the current UTC time. This 
+        method will be monkey patched when tested.
+        @return current date and time
+        '''
+        return datetime.datetime.utcnow()
+    def current_beat(self):
+        '''
+        Handles the math of finding a beat
+        @return current beat as a float
+        '''
+        now = self.current_datetime()
+        midnight = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        beat = ( (now - midnight).seconds + 3600) / 86.4
+        # 1000.000000 >= 1000.0 was not passing, so using rounded values
+        if round(beat) >= 1000:
+            beat = math.copysign(beat-1000.0, 0)
+        return beat

--- a/test/segments_test/beat_test.py
+++ b/test/segments_test/beat_test.py
@@ -1,0 +1,84 @@
+import unittest
+import datetime
+import mock
+import powerline_shell.segments.beat as beat
+from powerline_shell.themes.default import Color
+from argparse import Namespace
+
+class BeatTest(unittest.TestCase):
+    def setUp(self):
+        self.powerline = mock.MagicMock()
+        self.powerline.theme = Color
+        self.segment = beat.Segment(self.powerline, {})
+        self.segment.current_datetime = self.patch_date1
+
+    def test_colorize(self):
+        self.powerline.segment_conf.return_value = True
+        self.segment.start()
+        self.segment.add_to_powerline()
+        args = self.powerline.append.call_args[0]
+        self.assertRegex(args[0], r'@\d{3}\.\d')
+        self.assertEqual(args[1], Color.TIME_FG)
+        self.assertEqual(args[2], Color.TIME_BG)
+
+    def test_config(self):
+        self.segment = beat.Segment(self.powerline,
+            {"show_at_sign":"False", "show_decimal":"False"})
+        self.segment.current_datetime = self.patch_date1
+        
+        self.powerline.segment_conf.return_value = True
+        self.segment.start()
+        self.segment.add_to_powerline()
+        args = self.powerline.append.call_args[0]
+        self.assertRegex(args[0], r'305', "config check")
+
+    def test_beat(self):
+        self.segment.current_datetime = self.patch_date1
+
+        self.powerline.segment_conf.return_value = True
+        self.segment.start()
+        self.segment.add_to_powerline()
+        args = self.powerline.append.call_args[0]
+        self.assertRegex(args[0], "@305.6", "specific time")
+
+    def test_beat_rollover(self):
+        self.segment.current_datetime = self.patch_date2
+        
+        # start before transition
+        self.powerline.segment_conf.return_value = True
+        self.segment.start()
+        self.segment.add_to_powerline()
+        args = self.powerline.append.call_args[0]
+        self.assertRegex(args[0], "@999.3", "before transition")
+        
+        self.segment.current_datetime = self.patch_date3
+        
+        # test transition at @000.0
+        self.powerline.segment_conf.return_value = True
+        self.segment.start()
+        self.segment.add_to_powerline()
+        args = self.powerline.append.call_args[0]
+        self.assertRegex(args[0], "@000.0", "at transition")
+        
+        # now test the other side of transition
+        self.segment.current_datetime = self.patch_date4
+
+        self.powerline.segment_conf.return_value = True
+        self.segment.start()
+        self.segment.add_to_powerline()
+        args = self.powerline.append.call_args[0]
+        self.assertRegex(args[0], "@000.7", "after transition")
+
+    # ######################################################################
+
+    def patch_date1(self):
+        return datetime.datetime(2019, 6, 20, 6, 20) #@305.6
+
+    def patch_date2(self):
+        return datetime.datetime(2019, 6, 20, 22, 59) #@999.3
+
+    def patch_date3(self):
+        return datetime.datetime(2019, 6, 20, 23, 0) #@000.0
+
+    def patch_date4(self):
+        return datetime.datetime(2019, 6, 20, 23, 1) #@000.7


### PR DESCRIPTION
I created a beat time segment for displaying 'internet time' on the prompt. Beat time (https://en.wikipedia.org/wiki/Swatch_Internet_Time) is a timezone independent way of representing the time of day. Beat time is very compact and can be used for logging time of commands (or in screen shots). Logs are comparable regardless of timezones.