### PR TITLE
#468 - adding a check for env

### DIFF
--- a/powerline_shell/segments/env.py
+++ b/powerline_shell/segments/env.py
@@ -4,7 +4,11 @@ from ..utils import BasicSegment
 
 class Segment(BasicSegment):
     def add_to_powerline(self):
-        self.powerline.append(
-            " %s " % os.getenv(self.segment_def["var"]),
-            self.segment_def.get("fg_color", self.powerline.theme.PATH_FG),
-            self.segment_def.get("bg_color", self.powerline.theme.PATH_BG))
+        env = os.getenv(self.segment_def["var"])
+        if env is None:
+            env = self.segment_def["default"]
+        if env is not None:
+            self.powerline.append(
+                " %s " % env,
+                self.segment_def.get("fg_color", self.powerline.theme.PATH_FG),
+                self.segment_def.get("bg_color", self.powerline.theme.PATH_BG))


### PR DESCRIPTION
adding a check for env and providing a default if it does not exist. Configuration can now look like:

{"type": "env", "var": "FAKE_ENV", "default":"no fake"}