### PR TITLE
Fix for issue #408

### DIFF
--- a/powerline_shell/segments/svn.py
+++ b/powerline_shell/segments/svn.py
@@ -7,6 +7,8 @@ def _get_svn_revision():
                          stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE,
                          env=get_subprocess_env())
+
+    revision = None
     for line in p.communicate()[0].decode("utf-8").splitlines():
         if "revision" in line:
             revision = line.split("=")[1].split('"')[1]
@@ -66,5 +68,7 @@ class Segment(ThreadedSegment):
             symbol = " " + RepoStats().symbols["svn"]
         else:
             symbol = ""
-        self.powerline.append(symbol + " rev " + self.revision + " ", fg, bg)
+
+        if self.revision:
+            self.powerline.append(symbol + " rev " + self.revision + " ", fg, bg)
         self.stats.add_to_powerline(self.powerline)


### PR DESCRIPTION
The SVN repo error appears whenever we `cd` into a non-versioned directory of a checked out repo. `svn status` indicates that the current directory is not versioned yet, but svn info does not display any info (hence no revision info).

The fix does not print the revision segment in this specific case (but shows the modified repository indicator).

Tested with SVN 1.7.14