### PR TITLE
Improve hostname colorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,10 +299,13 @@ The options for the `cwd` segment are:
 - `full_cwd`: If true, the last directory will not be shortened when
   `max_dir_size` is used.
 
-The `hostname` segment provides one option:
+The `hostname` segment provides two options:
 
 - `colorize`: If true, the hostname will be colorized based on a hash of
   itself.
+
+- `dark`: If true (and colorize=true), a bright color will be used as the 
+  background color
 
 The `vcs` segment provides one option:
 

--- a/powerline_shell/color_compliment.py
+++ b/powerline_shell/color_compliment.py
@@ -10,21 +10,11 @@ from .utils import py3
 
 
 def getOppositeColor(r,g,b):
-    r, g, b = [x/255.0 for x in [r, g, b]] # convert to float before getting hls value
-    hls = rgb_to_hls(r,g,b)
-    opp = list(hls[:])
-    opp[0] = (opp[0]+0.2)%1 # shift hue (a.k.a. color)
-    if opp[1] > 255/2:   # for level you want to make sure they
-        opp[1] -= 255/2  # are quite different so easily readable
-    else:
-        opp[1] += 255/2
-    if opp[2] > -0.5: # if saturation is low on first color increase second's
-        opp[2] -= 0.5
-    opp = hls_to_rgb(*opp)
-    m = max(opp)
-    if m > 255: #colorsys module doesn't give caps to their conversions
-        opp = [ x*254/m for x in opp]
-    return tuple([ int(x) for x in opp])
+    """returns RGB components of complementary color"""
+    # colorsys functions expect values to be between 0 and 1
+    hls = rgb_to_hls(*[x/255.0 for x in [r, g, b]]) # r,g,b are now between 0 and 1
+    opp = hls_to_rgb(*[ (x+0.5)%1 for x in hls ])
+    return tuple([ int(x*255) for x in opp ]) # convert back to value range 0-255
 
 def stringToHashToColorAndOpposite(string):
     if py3:

--- a/powerline_shell/segments/hostname.py
+++ b/powerline_shell/segments/hostname.py
@@ -10,6 +10,11 @@ class Segment(BasicSegment):
         if powerline.segment_conf("hostname", "colorize"):
             hostname = gethostname()
             FG, BG = stringToHashToColorAndOpposite(hostname)
+            # if we operate on a dark background then
+            # we want the brighter color to always be the
+            # background color
+            if powerline.segment_conf("hostname", "dark") and sum(FG) > sum(BG):
+                FG,BG = BG,FG
             FG, BG = (rgb2short(*color) for color in [FG, BG])
             host_prompt = " %s " % hostname.split(".")[0]
             powerline.append(host_prompt, FG, BG)


### PR DESCRIPTION
There are 2 changes included:

a) The function getOppositeColor in color_compliment.py did not work properly. It was mixing value ranges from 0-1 and ranges from 0-255.

b) When hostname colorization is enabled, then a random number is being generated for the foreground color of the hostname and the opposite color is being calculated for the background color.

However, when running in a shell with dark background color it typically looks better if the background color of the hostname is "bright". So I introduced a noption in the configuration named "hostname.dark" that (when set to true) picks the brighter of the two colors for the hostname as the background color.
