### PR TITLE
Config options added to truncate git branch names

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,11 @@ The `vcs` segment provides one option:
 - `show_symbol`: If `true`, the version control system segment will start with
   a symbol representing the specific version control system in use in the
   current directory.
+  
+The options for the `git` segment are:
+
+- `master_is_M`: If `true`, the master branch will be abbreviated to M.
+- `branch_max_length`: Maximum number of characters displayed for the branch name.
 
 The options for the `battery` segment are:
 

--- a/powerline_shell/segments/git.py
+++ b/powerline_shell/segments/git.py
@@ -66,7 +66,17 @@ def build_stats():
 class Segment(ThreadedSegment):
     def run(self):
         self.stats, self.branch = build_stats()
+        
+        # Abbreviates master branch to M
+        if self.powerline.segment_conf("git", "master_is_M"):
+            if self.branch == "master":     
+                 self.branch = "M"
 
+        # Truncates branch length
+        branch_max_length = self.powerline.segment_conf("git", "branch_max_length", -1)
+        if len(self.branch) > branch_max_length :
+            self.branch = self.branch = self.branch[:branch_max_length] + u'\u2026' 
+        
     def add_to_powerline(self):
         self.join()
         if not self.stats:

--- a/powerline_shell/segments/git.py
+++ b/powerline_shell/segments/git.py
@@ -75,7 +75,7 @@ class Segment(ThreadedSegment):
         # Truncates branch length
         branch_max_length = self.powerline.segment_conf("git", "branch_max_length", -1)
         if len(self.branch) > branch_max_length :
-            self.branch = self.branch = self.branch[:branch_max_length] + u'\u2026' 
+            self.branch = self.branch[:branch_max_length] + u'\u2026' 
         
     def add_to_powerline(self):
         self.join()


### PR DESCRIPTION
This is related to #438 . I added two options to truncate git branch names to use with `config.json`.
```
  "git": {
      "master_is_M": true,
      "branch_max_length": 5
  }
```

The first abbreviates master to M. The second sets a maximum number of characters to display for the branch name. Names past that length are truncated and appended with the unicode ellipsis.

I didn't look at bzr or other vc systems, so I kept this git specific.