### PR TITLE
Fix `Initialize Segment instance variables

### DIFF
--- a/powerline_shell/segments/hg.py
+++ b/powerline_shell/segments/hg.py
@@ -48,6 +48,9 @@ def build_stats():
 
 
 class Segment(ThreadedSegment):
+    def __init__(self):
+        self.stats, self.branch = None, None
+    
     def run(self):
         self.stats, self.branch = build_stats()
 


### PR DESCRIPTION
Initialize stats and branch of the Segment class to None.

This should hopefully fix the issue outline in https://github.com/b-ryan/powerline-shell/issues/408:

```
AttributeError: 'Segment' object has no attribute 'stats'
```