### PR TITLE
Don't treat directories as files

### DIFF
--- a/powerline_shell/__init__.py
+++ b/powerline_shell/__init__.py
@@ -149,7 +149,7 @@ def find_config():
         os.path.join(os.environ.get("XDG_CONFIG_HOME", "~/.config"), "powerline-shell", "config.json"),
     ]:
         full = os.path.expanduser(location)
-        if os.path.exists(full):
+        if os.path.isfile(full):
             return full
 
 DEFAULT_CONFIG = {


### PR DESCRIPTION
Powerline apparently blows up if you enter a directory which contains a directory named "powerline-shell.json".

This fixes it.