### PR TITLE
prevent rbenv segment from spamming errors

### DIFF
--- a/powerline_shell/segments/rbenv.py
+++ b/powerline_shell/segments/rbenv.py
@@ -6,7 +6,7 @@ class Segment(BasicSegment):
     def add_to_powerline(self):
         powerline = self.powerline
         try:
-            p1 = subprocess.Popen(["rbenv", "local"], stdout=subprocess.PIPE)
+            p1 = subprocess.Popen(["rbenv", "local"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             version = p1.communicate()[0].decode("utf-8").rstrip()
             if len(version) <= 0:
                     return


### PR DESCRIPTION
`rbenv local` returns non-zero return code, as well as prints `rbenv: no local version configured for this directory` for directories which do not have rbenv configuration. 
Including `rbenv` in segments caused this error message to be printed each time PS1 was evaluated. This change prevents `rbenv local` stderr from being printed out. 