### PR TITLE
Adding TrueColor/RGB support to themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,10 +261,17 @@ to the path of the file. For example your configuration might have:
   "theme": "~/mythemes/my-great-theme.py"
 ```
 
-You can then modify the color codes to your liking. Theme colors are specified
-using [Xterm-256 color codes](https://jonasjacek.github.io/colors/).
+You can then modify the color codes to your liking. Theme colors can be specified
+using [Xterm-256 color codes](https://jonasjacek.github.io/colors/), or using RGB tuple values
+if your terminal supports TrueColor. To check if this is the case, you can run:
 
-A script for testing color combinations is provided at `colortest.py`. Note
+```
+  $ echo $COLORTERM
+```
+
+If `truecolor` is printed, you're good to go with RGB values.
+
+Scripts for testing color combinations are provided at `colortest.py` and `colortest_truecolor.py`. Note
 that the colors you see may vary depending on your terminal. When designing a
 theme, please test your theme on multiple terminals, especially with default
 settings.

--- a/colortest_truecolor.py
+++ b/colortest_truecolor.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python2
+import sys
+
+ESCAPE = chr(27)
+
+def fg(color):
+    return ESCAPE + '[38;2;%d;%d;%dm' % color
+
+def bg(color):
+    return ESCAPE + '[48;2;%d;%d;%dm' % color
+
+def reset():
+    return ESCAPE + '[48;0m'
+
+if __name__ == "__main__":
+    if len(sys.argv) < 8:
+        print 'Usage: colortest_truecolor.py fg_red fg_green fg_blue bg_red bg_green bg_blue test_string'
+        sys.exit(1)
+    
+    fg_red, fg_green, fg_blue, bg_red, bg_green, bg_blue = map(int, sys.argv[1:-1])
+    test_string = sys.argv[-1]
+
+    print bg((bg_red, bg_green, bg_blue)), fg((fg_red, fg_green, fg_blue)), test_string, reset()

--- a/powerline_shell/__init__.py
+++ b/powerline_shell/__init__.py
@@ -87,8 +87,6 @@ class Powerline(object):
     def __init__(self, args, config, theme):
         self.args = args
         self.config = config
-        theme_wants_truecolor = hasattr(theme, "use_truecolor") and theme.use_truecolor
-
         env_colorterm = os.getenv("COLORTERM")
         self.truecolor_supported = env_colorterm is not None and "truecolor" in env_colorterm
         self.theme = theme


### PR DESCRIPTION
I've added TrueColor support to the color system, to allow for themes to be more flexible in their color usage rather than being limited to only xterm-256 color space.

The `Powerline` ctor now checks for TrueColor support by checking the `COLORTERM` environment variable, and sets a flag.

The `color()` function in `powerline_shell/__init__.py` both checks this flag, as well as the type of the color information coming in from the theme. If the color is an integer, it is applied as an xterm-256 color as normal. If the color is an RGB tuple, however, one of two things happens:
* If the terminal **does** support TrueColor, the color is applied using an alternative color coding string
* If the terminal **does not** support TrueColor, the color is converted to the closest xterm-256 color using `colortrans.rgb2short` before being applied.

Color fallback works as normal if a theme doesn't specify a color for a certain segment property.

I've also added a color test script specifically for TrueColor, however it only allows for testing one background and foreground color each, since interpolating between two RGB values for each would be intensive, and likely not fit cleanly on a user's terminal.