### PR TITLE
Update README.md (zsh example)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ function install_powerline_precmd() {
   precmd_functions+=(powerline_precmd)
 }
 
-if [ "$TERM" != "linux" ]; then
+if [ "$TERM" != "linux" -a -x "$(command -v powerline-shell)" ]; then
     install_powerline_precmd
 fi
 ```


### PR DESCRIPTION
When `powerline-shell` command becomes not accessible accidentally, shell will not work but print the error message like `powerline_precmd:1: command not found: powerline-shell` constantly.

This PR updates zsh example in README.md to activate powerline-shell only when the command is found.