### PR TITLE
Add option to require package.json for node_version segment

### DIFF
--- a/powerline_shell/segments/node_version.py
+++ b/powerline_shell/segments/node_version.py
@@ -1,5 +1,5 @@
 import subprocess
-from ..utils import ThreadedSegment
+from ..utils import ThreadedSegment, find_upwards
 
 
 class Segment(ThreadedSegment):
@@ -12,7 +12,14 @@ class Segment(ThreadedSegment):
 
     def add_to_powerline(self):
         self.join()
+
+        require_package = self.powerline.segment_conf("node_version", "require_package", False)
+        chars = int(self.powerline.segment_conf("node_version", "chars", 10))
+        has_package = find_upwards("package.json") != None
+
+        if require_package and not has_package:
+            return
         if not self.version:
             return
         # FIXME no hard-coded colors
-        self.powerline.append("node " + self.version, 15, 18)
+        self.powerline.append(" node " + self.version[:chars], 15, 18)

--- a/powerline_shell/segments/node_version.py
+++ b/powerline_shell/segments/node_version.py
@@ -22,4 +22,4 @@ class Segment(ThreadedSegment):
         if not self.version:
             return
         # FIXME no hard-coded colors
-        self.powerline.append(" node " + self.version[:chars], 15, 18)
+        self.powerline.append(" node " + self.version[:chars] + " ", 15, 18)

--- a/powerline_shell/utils.py
+++ b/powerline_shell/utils.py
@@ -1,6 +1,7 @@
 import sys
 import os
 import threading
+from pathlib import Path
 
 py3 = sys.version_info[0] == 3
 
@@ -150,3 +151,9 @@ def get_git_subprocess_env():
     # Otherwise we may be unable to parse the output.
     return get_subprocess_env(LANG="C")
 
+
+def find_upwards(filename: str, cwd: Path = Path.cwd()) -> Path | None:
+    if cwd == Path(cwd.root) or cwd == cwd.parent:
+        return None
+    fullpath = cwd / filename
+    return fullpath if fullpath.exists() else find_upwards(filename, cwd.parent)


### PR DESCRIPTION
I added some features to the node_version segment to make it more configurable and fit my needs better.

## Configuration Variables

If "requires_package" is set to true, then the segment will not add the segment if it does not find a "package.json" file in the path to the root.
I also added "chars" which is the number of characters of the output of `node --version` to display.

#### Example Configuration:

``` json
{
  "segments": [
    "node_version"
  ],
  "node_version": {
      "require_package": true,
      "chars": 3
  }
}
```

#### Default

![image](https://user-images.githubusercontent.com/32819501/211130767-5087d376-ecfb-4332-9c5c-c89cf9d93a3f.png)

#### With "chars": 3

![image](https://user-images.githubusercontent.com/32819501/211130855-3d268b89-611f-4587-9759-be2deacdf410.png)

Note: these screenshots are before I made a change to add a space at the end of the segment.