### PR TITLE
raw_uptime NoneType has no group attribute bugfix

### DIFF
--- a/powerline_shell/segments/uptime.py
+++ b/powerline_shell/segments/uptime.py
@@ -8,7 +8,8 @@ class Segment(BasicSegment):
         powerline = self.powerline
         try:
             output = decode(subprocess.check_output(['uptime'], stderr=subprocess.STDOUT))
-            raw_uptime = re.search('(?<=up).+(?=,\s+\d+\s+user)', output).group(0)
+            raw_uptime = re.search('(?<=up).+(?=,\s+\d+\s+user)', output)
+            raw_uptime = '' if not raw_uptime else raw_uptime.group(0)
             day_search = re.search('\d+(?=\s+day)', output)
             days = '' if not day_search else '%sd ' % day_search.group(0)
             hour_search =  re.search('\d{1,2}(?=\:)', raw_uptime)


### PR DESCRIPTION
A rare edge case is possible with the uptime segment where the uptime `re.search` can produce a `None` and so the `.group(0)` will break it. This is a quick fix for that.

This logic is clearly used in the lines below it. The original author of this segment must have missed this line