### PR TITLE
Add k8s segment to show context and namespace info

### DIFF
--- a/powerline_shell/segments/k8s.py
+++ b/powerline_shell/segments/k8s.py
@@ -4,6 +4,7 @@ from ..utils import BasicSegment
 from ..colortrans import rgb2short
 from ..color_compliment import stringToHashToColorAndOpposite
 
+EMPTY = ''
 
 def kube_info(cmd):
     try:
@@ -12,53 +13,53 @@ def kube_info(cmd):
                              stderr=subprocess.PIPE,
                              env=os.environ.copy())
     except OSError:
-        return ''
+        return EMPTY
 
-    pdata = p.communicate()
-    if p.returncode != 0:
-        return ''
+    data = p.communicate()
+    if p.returncode:
+        return EMPTY
 
-    return ''.join(pdata[0].decode("utf-8").splitlines())
+    return data[0].decode('utf-8').splitlines()[0]
 
 
 def ellipse(string, length):
     if length > 0:
         return (string[:length] + '~') if len(string) > length else string
     else:
-        return ''
+        return EMPTY
 
 
 class Segment(BasicSegment):
     def add_to_powerline(self):
+        kctx = kube_info('kubectl-ctx -c')
+        if not kctx:
+            return                          # no context, nothing to do
+
         powerline = self.powerline
 
-        kctx = kube_info("kubectl-ctx -c")
-        if not kctx: # without context there's nothing to do
-            return
-
         kctx = ellipse(kctx,
-                       powerline.segment_conf("k8s", "max_context"))
+                       powerline.segment_conf('k8s', 'max_context'))
 
         kns = ellipse(kube_info("kubectl-ns -c"),
-                      powerline.segment_conf("k8s", "max_namespace"))
+                      powerline.segment_conf('k8s', 'max_namespace'))
 
-        status = kctx + ('|' if kctx and kns else '') + kns
+        status = kctx + ('|' if kctx and kns else EMPTY) + kns
 
         bg = powerline.theme.K8S_BG
         fg = powerline.theme.K8S_FG
         sym_fg = powerline.theme.K8S_SYMBOL_FG
 
-        if powerline.segment_conf("k8s", "colorize"):
+        if powerline.segment_conf('k8s', 'colorize'):
             bg, fg = stringToHashToColorAndOpposite(status)
             fg, bg = (rgb2short(*color) for color in [fg, bg])
 
-            if powerline.segment_conf("k8s", "colorize_symbol"):
+            if powerline.segment_conf('k8s', 'colorize_symbol'):
                 sym_fg = fg
 
-        lspace = '' if powerline.segment_conf("k8s", "ltrim") else ' '
-        rspace = '' if powerline.segment_conf("k8s", "rtrim") else ' '
+        lspace = EMPTY if powerline.segment_conf('k8s', 'ltrim') else ' '
+        rspace = EMPTY if powerline.segment_conf('k8s', 'rtrim') else ' '
 
-        if powerline.segment_conf("k8s", "symbol"):
+        if powerline.segment_conf('k8s', 'symbol'):
             powerline.append(lspace + U'\U0001F578' + ' ', sym_fg, bg)
             powerline.append(status + rspace, fg, bg)
         else:

--- a/powerline_shell/segments/k8s.py
+++ b/powerline_shell/segments/k8s.py
@@ -1,0 +1,65 @@
+import os
+import subprocess
+from ..utils import BasicSegment
+from ..colortrans import rgb2short
+from ..color_compliment import stringToHashToColorAndOpposite
+
+
+def kube_info(cmd):
+    try:
+        p = subprocess.Popen(cmd.split(),
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE,
+                             env=os.environ.copy())
+    except OSError:
+        return ''
+
+    pdata = p.communicate()
+    if p.returncode != 0:
+        return ''
+
+    return ''.join(pdata[0].decode("utf-8").splitlines())
+
+
+def ellipse(string, length):
+    if length > 0:
+        return (string[:length] + '~') if len(string) > length else string
+    else:
+        return ''
+
+
+class Segment(BasicSegment):
+    def add_to_powerline(self):
+        powerline = self.powerline
+
+        kctx = kube_info("kubectl-ctx -c")
+        if not kctx: # without context there's nothing to do
+            return
+
+        kctx = ellipse(kctx,
+                       powerline.segment_conf("k8s", "max_context"))
+
+        kns = ellipse(kube_info("kubectl-ns -c"),
+                      powerline.segment_conf("k8s", "max_namespace"))
+
+        status = kctx + ('|' if kctx and kns else '') + kns
+
+        bg = powerline.theme.K8S_BG
+        fg = powerline.theme.K8S_FG
+        sym_fg = powerline.theme.K8S_SYMBOL_FG
+
+        if powerline.segment_conf("k8s", "colorize"):
+            bg, fg = stringToHashToColorAndOpposite(status)
+            fg, bg = (rgb2short(*color) for color in [fg, bg])
+
+            if powerline.segment_conf("k8s", "colorize_symbol"):
+                sym_fg = fg
+
+        lspace = '' if powerline.segment_conf("k8s", "ltrim") else ' '
+        rspace = '' if powerline.segment_conf("k8s", "rtrim") else ' '
+
+        if powerline.segment_conf("k8s", "symbol"):
+            powerline.append(lspace + U'\U0001F578' + ' ', sym_fg, bg)
+            powerline.append(status + rspace, fg, bg)
+        else:
+            powerline.append(lspace + status + rspace, fg, bg)

--- a/powerline_shell/themes/default.py
+++ b/powerline_shell/themes/default.py
@@ -72,6 +72,10 @@ class DefaultColor(object):
     AWS_PROFILE_FG = 39
     AWS_PROFILE_BG = 238
 
+    K8S_FG = 57
+    K8S_BG = 7
+    K8S_SYMBOL_FG = 57
+
     TIME_FG = 250
     TIME_BG = 238
 


### PR DESCRIPTION
Hi, I added this segment to avoid making mistakes when using multiple k8s contexts/namespaces.

Hope you find it useful, any corrections welcome, and if something is missing for integration, just let me know. 

**Requirements**
  kubectx and kubens from https://github.com/ahmetb/kubectx in PATH

**Configuration**

```
  "k8s": {
    "ltrim": bool,
    "rtrim": bool,
    "symbol": bool,
    "max_context": number,
    "max_namespace": number,
    "colorize": bool,
    "colorize_symbol": bool
  }
```

ltrim, rtrim: do not add space at left or right (compatibility with some theme mods)

symbol: show k8s symbol

max_context, max_namespace: cut with an ellipsis context or namespace, use 0 to supress output

colorize, colorize_symbol: auto-colorize based on the information string

**Theme**
  K8S_FG = 57
  K8S_BG = 7
  K8S_SYMBOL_FG = 57