### PR TITLE
Fix Tests Under Python 3 and Run In CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,37 @@
+name: Python Tests
+
+on:
+  - push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    container:
+      image: ubuntu:22.04
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+
+      - name: Install binary dependencies
+        run: apt update && apt install -y git bzr fossil mercurial subversion
+        env:
+          DEBIAN_FRONTEND: noninteractive
+
+      - name: Install Python dependencies
+        run: python -m pip install -r requirements-dev.txt
+
+      - name: Run Python Tests
+        run: python -m pytest --junitxml=test-results.xml
+
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v4
+        if: success() || failure() # always run even if the previous step fails
+        with:
+          report_paths: 'test-results.xml'

--- a/powerline_shell/segments/uptime.py
+++ b/powerline_shell/segments/uptime.py
@@ -1,19 +1,19 @@
 import subprocess
 import re
-from ..utils import BasicSegment, decode
+from ..utils import BasicSegment
 
 
 class Segment(BasicSegment):
     def add_to_powerline(self):
         powerline = self.powerline
         try:
-            output = decode(subprocess.check_output(['uptime'], stderr=subprocess.STDOUT))
-            raw_uptime = re.search('(?<=up).+(?=,\s+\d+\s+user)', output).group(0)
-            day_search = re.search('\d+(?=\s+day)', output)
+            output = subprocess.check_output(['uptime'], stderr=subprocess.STDOUT)
+            raw_uptime = re.search(r'(?<=up).+(?=,\s+\d+\s+user)', output).group(0)
+            day_search = re.search(r'\d+(?=\s+day)', output)
             days = '' if not day_search else '%sd ' % day_search.group(0)
-            hour_search =  re.search('\d{1,2}(?=\:)', raw_uptime)
+            hour_search = re.search(r'\d{1,2}(?=\:)', raw_uptime)
             hours = '' if not hour_search else '%sh ' %  hour_search.group(0)
-            minutes =  re.search('(?<=\:)\d{1,2}|\d{1,2}(?=\s+min)', raw_uptime).group(0)
+            minutes = re.search(r'(?<=\:)\d{1,2}|\d{1,2}(?=\s+min)', raw_uptime).group(0)
             uptime = u' %s%s%sm \u2191 ' % (days, hours, minutes)
             powerline.append(uptime, powerline.theme.CWD_FG, powerline.theme.PATH_BG)
         except OSError:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
-mock>=1.3.0
 sh>=1.11
 parameterized>=0.6.1
 pytest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ nose>=1.3.7
 mock>=1.3.0
 sh>=1.11
 parameterized>=0.6.1
+pytest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
-nose>=1.3.7
 mock>=1.3.0
 sh>=1.11
 parameterized>=0.6.1

--- a/test/color_compliment_test.py
+++ b/test/color_compliment_test.py
@@ -7,7 +7,7 @@ from powerline_shell.color_compliment import getOppositeColor
 def build_inputs():
     
     # Build 768 hex/rgb values to test against getOppositeColor
-    input_bytes = map(hex, xrange(pow(2,8)))
+    input_bytes = list(map(hex, range(pow(2,8))))
 
     input_list = []
     for x in input_bytes:

--- a/test/cwd_test.py
+++ b/test/cwd_test.py
@@ -3,6 +3,9 @@ import mock
 import os
 import tempfile
 import shutil
+
+import sh
+
 import powerline_shell as p
 
 
@@ -33,9 +36,9 @@ class CwdTest(unittest.TestCase):
     @mock.patch('powerline_shell.warn')
     def test_falls_back_to_getcwd(self, warn, getenv):
         getenv.return_value = None
-        os.chdir(self.dirname)
-        self.assertEqual(p.get_valid_cwd(), self.dirname)
-        self.assertEqual(warn.call_count, 0)
+        with sh.pushd(self.dirname):
+            self.assertEqual(p.get_valid_cwd(), self.dirname)
+            self.assertEqual(warn.call_count, 0)
 
     @mock.patch('os.getenv')
     @mock.patch('powerline_shell.warn')
@@ -44,10 +47,10 @@ class CwdTest(unittest.TestCase):
         getenv.return_value = None
 
         os.mkdir(subdir)
-        os.chdir(subdir)
-        os.rmdir(subdir)
+        with sh.pushd(subdir):
+            os.rmdir(subdir)
 
-        with self.assertRaises(SystemExit) as e:
-            p.get_valid_cwd()
+            with self.assertRaises(SystemExit) as e:
+                p.get_valid_cwd()
 
-        self.assertEqual(warn.call_count, 1)
+            self.assertEqual(warn.call_count, 1)

--- a/test/cwd_test.py
+++ b/test/cwd_test.py
@@ -1,5 +1,5 @@
 import unittest
-import mock
+from unittest import mock
 import os
 import tempfile
 import shutil

--- a/test/segments_test/bzr_test.py
+++ b/test/segments_test/bzr_test.py
@@ -1,4 +1,6 @@
 import unittest
+from contextlib import ExitStack
+
 import mock
 import tempfile
 import shutil
@@ -28,13 +30,19 @@ class BzrTest(unittest.TestCase):
         })
 
         self.dirname = tempfile.mkdtemp()
-        sh.cd(self.dirname)
-        sh.bzr("init-repo", ".")
-        sh.mkdir("trunk")
-        sh.cd("trunk")
-        sh.bzr("init")
+        with sh.pushd(self.dirname):
+            sh.bzr("init-repo", ".")
+            sh.mkdir("trunk")
+
+        with sh.pushd(self.dirname + "/trunk"):
+            sh.bzr("init")
+            sh.bzr("whoami", "--branch", '"Example <example@example.com>"')
 
         self.segment = bzr.Segment(self.powerline, {})
+
+        with ExitStack() as stack:
+            self._resource = stack.enter_context(sh.pushd(self.dirname + "/trunk"))
+            self.addCleanup(stack.pop_all().close)
 
     def tearDown(self):
         shutil.rmtree(self.dirname)
@@ -45,9 +53,8 @@ class BzrTest(unittest.TestCase):
         sh.bzr("commit", "-m", "add file " + filename)
 
     def _checkout_new_branch(self, branch):
-        sh.cd("..")
-        sh.bzr("branch", "trunk", branch)
-        sh.cd(branch)
+        with sh.pushd(self.dirname):
+            sh.bzr("branch", "trunk", branch)
 
     @mock.patch("powerline_shell.utils.get_PATH")
     def test_bzr_not_installed(self, get_PATH):
@@ -71,12 +78,14 @@ class BzrTest(unittest.TestCase):
     def test_different_branch(self):
         self._add_and_commit("foo")
         self._checkout_new_branch("bar")
-        self.segment.start()
-        self.segment.add_to_powerline()
-        self.assertEqual(self.powerline.append.call_args[0][0], " bar ")
+        with sh.pushd(self.dirname + "/bar"):
+            self.segment.start()
+            self.segment.add_to_powerline()
+            self.assertEqual(self.powerline.append.call_args[0][0], " bar ")
 
     @mock.patch('powerline_shell.segments.bzr._get_bzr_status')
     def test_all(self, check_output):
         for stdout, result in test_cases:
-            stats = bzr.parse_bzr_stats(stdout)
-            self.assertEquals(result, stats)
+            with sh.pushd(self.dirname + "/trunk"):
+                stats = bzr.parse_bzr_stats(stdout)
+                self.assertEqual(result, stats)

--- a/test/segments_test/bzr_test.py
+++ b/test/segments_test/bzr_test.py
@@ -1,7 +1,7 @@
 import unittest
 from contextlib import ExitStack
 
-import mock
+from unittest import mock
 import tempfile
 import shutil
 import sh

--- a/test/segments_test/fossil_test.py
+++ b/test/segments_test/fossil_test.py
@@ -1,5 +1,6 @@
 import unittest
 from contextlib import ExitStack
+from os import environ
 
 import mock
 import tempfile
@@ -19,6 +20,7 @@ test_cases = {
 
 class FossilTest(unittest.TestCase):
 
+    @mock.patch.dict(environ, {"USER": "root"})
     def setUp(self):
         self.powerline = mock.MagicMock()
         self.powerline.segment_conf.side_effect = dict_side_effect_fn({
@@ -61,12 +63,14 @@ class FossilTest(unittest.TestCase):
         self.segment.add_to_powerline()
         self.assertEqual(self.powerline.append.call_count, 0)
 
+    @mock.patch.dict(environ, {"USER": "root"})
     def test_standard(self):
         self._add_and_commit("foo")
         self.segment.start()
         self.segment.add_to_powerline()
         self.assertEqual(self.powerline.append.call_args[0][0], " trunk ")
 
+    @mock.patch.dict(environ, {"USER": "root"})
     def test_different_branch(self):
         self._add_and_commit("foo")
         self._checkout_new_branch("bar")

--- a/test/segments_test/fossil_test.py
+++ b/test/segments_test/fossil_test.py
@@ -2,7 +2,7 @@ import unittest
 from contextlib import ExitStack
 from os import environ
 
-import mock
+from unittest import mock
 import tempfile
 import shutil
 import sh

--- a/test/segments_test/git_stash_test.py
+++ b/test/segments_test/git_stash_test.py
@@ -16,6 +16,8 @@ class GitStashTest(unittest.TestCase):
         self.dirname = tempfile.mkdtemp()
         with sh.pushd(self.dirname):
             sh.git("init", ".")
+            sh.git("config", "user.name", "Test")
+            sh.git("config", "user.email", "example@example.com")
 
         self.segment = git_stash.Segment(self.powerline, {})
 

--- a/test/segments_test/git_stash_test.py
+++ b/test/segments_test/git_stash_test.py
@@ -1,4 +1,6 @@
 import unittest
+from contextlib import ExitStack
+
 import mock
 import tempfile
 import shutil
@@ -12,10 +14,14 @@ class GitStashTest(unittest.TestCase):
     def setUp(self):
         self.powerline = mock.MagicMock()
         self.dirname = tempfile.mkdtemp()
-        sh.cd(self.dirname)
-        sh.git("init", ".")
+        with sh.pushd(self.dirname):
+            sh.git("init", ".")
 
         self.segment = git_stash.Segment(self.powerline, {})
+
+        with ExitStack() as stack:
+            self._resource = stack.enter_context(sh.pushd(self.dirname))
+            self.addCleanup(stack.pop_all().close)
 
     def tearDown(self):
         shutil.rmtree(self.dirname)

--- a/test/segments_test/git_stash_test.py
+++ b/test/segments_test/git_stash_test.py
@@ -1,7 +1,7 @@
 import unittest
 from contextlib import ExitStack
 
-import mock
+from unittest import mock
 import tempfile
 import shutil
 import sh

--- a/test/segments_test/git_test.py
+++ b/test/segments_test/git_test.py
@@ -20,6 +20,8 @@ class GitTest(unittest.TestCase):
         self.dirname = tempfile.mkdtemp()
         with sh.pushd(self.dirname):
             sh.git("init", ".")
+            sh.git("config", "user.name", "Test")
+            sh.git("config", "user.email", "example@example.com")
 
         self.segment = git.Segment(self.powerline, {})
 

--- a/test/segments_test/git_test.py
+++ b/test/segments_test/git_test.py
@@ -1,7 +1,7 @@
 import unittest
 from contextlib import ExitStack
 
-import mock
+from unittest import mock
 import tempfile
 import shutil
 import sh

--- a/test/segments_test/hg_test.py
+++ b/test/segments_test/hg_test.py
@@ -1,4 +1,6 @@
 import unittest
+from contextlib import ExitStack
+
 import mock
 import tempfile
 import shutil
@@ -26,10 +28,14 @@ class HgTest(unittest.TestCase):
         })
 
         self.dirname = tempfile.mkdtemp()
-        sh.cd(self.dirname)
-        sh.hg("init", ".")
+        with sh.pushd(self.dirname):
+            sh.hg("init", ".")
 
         self.segment = hg.Segment(self.powerline, {})
+
+        with ExitStack() as stack:
+            self._resource = stack.enter_context(sh.pushd(self.dirname))
+            self.addCleanup(stack.pop_all().close)
 
     def tearDown(self):
         shutil.rmtree(self.dirname)
@@ -72,4 +78,4 @@ class HgTest(unittest.TestCase):
     def test_all(self, check_output):
         for stdout, result in test_cases.items():
             stats = hg.parse_hg_stats([stdout])
-            self.assertEquals(result, stats)
+            self.assertEqual(result, stats)

--- a/test/segments_test/hg_test.py
+++ b/test/segments_test/hg_test.py
@@ -1,7 +1,7 @@
 import unittest
 from contextlib import ExitStack
 
-import mock
+from unittest import mock
 import tempfile
 import shutil
 import sh

--- a/test/segments_test/hostname_test.py
+++ b/test/segments_test/hostname_test.py
@@ -1,5 +1,5 @@
 import unittest
-import mock
+from unittest import mock
 import powerline_shell.segments.hostname as hostname
 from powerline_shell.themes.default import Color
 from argparse import Namespace

--- a/test/segments_test/svn_test.py
+++ b/test/segments_test/svn_test.py
@@ -16,8 +16,8 @@ class SvnTest(unittest.TestCase):
         })
 
         self.dirname = tempfile.mkdtemp()
-        sh.cd(self.dirname)
-        # sh.svn("init", ".")
+        with sh.pushd(self.dirname):
+            sh.svn("init", ".")
 
         self.segment = svn.Segment(self.powerline, {})
 

--- a/test/segments_test/svn_test.py
+++ b/test/segments_test/svn_test.py
@@ -3,7 +3,7 @@ import unittest
 import shutil
 from contextlib import ExitStack
 
-import mock
+from unittest import mock
 import sh
 import powerline_shell.segments.svn as svn
 from ..testing_utils import dict_side_effect_fn

--- a/test/segments_test/svn_test.py
+++ b/test/segments_test/svn_test.py
@@ -1,6 +1,8 @@
 import tempfile
 import unittest
 import shutil
+from contextlib import ExitStack
+
 import mock
 import sh
 import powerline_shell.segments.svn as svn
@@ -15,18 +17,24 @@ class SvnTest(unittest.TestCase):
             ("vcs", "show_symbol"): False,
         })
 
-        self.dirname = tempfile.mkdtemp()
-        with sh.pushd(self.dirname):
-            sh.svn("init", ".")
+        self.upstream_dir = tempfile.mkdtemp()
+        self.checkout_dir = tempfile.mkdtemp()
+        sh.svnadmin("create", self.upstream_dir)
+        sh.svn("checkout", f"file://{self.upstream_dir}", self.checkout_dir)
 
         self.segment = svn.Segment(self.powerline, {})
 
+        with ExitStack() as stack:
+            self._resource = stack.enter_context(sh.pushd(self.checkout_dir))
+            self.addCleanup(stack.pop_all().close)
+
     def tearDown(self):
-        shutil.rmtree(self.dirname)
+        shutil.rmtree(self.upstream_dir)
+        shutil.rmtree(self.checkout_dir)
 
     @mock.patch("powerline_shell.utils.get_PATH")
     def test_svn_not_installed(self, get_PATH):
-        get_PATH.return_value = "" # so svn can't be found
+        get_PATH.return_value = ""  # so svn can't be found
         self.segment.start()
         self.segment.add_to_powerline()
         self.assertEqual(self.powerline.append.call_count, 0)

--- a/test/segments_test/uptime_test.py
+++ b/test/segments_test/uptime_test.py
@@ -1,5 +1,5 @@
 import unittest
-import mock
+from unittest import mock
 import powerline_shell.segments.uptime as uptime
 
 test_cases = {


### PR DESCRIPTION
This PR cleans up all the tests so they pass under Python 3.

To ensure all future changes don't break things, this also runs the tests in GitHub Actions.

Whilst in there, I've cleaned up the `svn` tests to look more like the other tests.