### PR TITLE
Remove Explicit Dependency on Argparse

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,6 @@ setup(
         "powerline_shell.segments",
         "powerline_shell.themes",
     ],
-    install_requires=[
-        "argparse",
-    ],
     entry_points="""
     [console_scripts]
     powerline-shell=powerline_shell:main


### PR DESCRIPTION
Argparse has been part of the Python stdlib since 2.7 and 3.2, so there is no need to explicitly depend on it.