### PR TITLE
cwd: Fix home indicator when HOME contains a symlink

### DIFF
--- a/powerline_shell/segments/cwd.py
+++ b/powerline_shell/segments/cwd.py
@@ -6,9 +6,10 @@ ELLIPSIS = u'\u2026'
 
 
 def replace_home_dir(cwd):
+    realcwd = os.path.realpath(cwd)
     home = os.path.realpath(os.getenv('HOME'))
-    if cwd.startswith(home):
-        return '~' + cwd[len(home):]
+    if realcwd.startswith(home):
+        return '~' + realcwd[len(home):]
     return cwd
 
 


### PR DESCRIPTION
Fixes #415. Supersedes #504.