### PR TITLE
Add `only_on_ssh` option for hostname segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,10 +299,11 @@ The options for the `cwd` segment are:
 - `full_cwd`: If true, the last directory will not be shortened when
   `max_dir_size` is used.
 
-The `hostname` segment provides one option:
+The `hostname` segment provides two options:
 
 - `colorize`: If true, the hostname will be colorized based on a hash of
   itself.
+- `only_on_ssh`: If true, the hostname will only be shown if connected via SSH.
 
 The `vcs` segment provides one option:
 

--- a/powerline_shell/segments/hostname.py
+++ b/powerline_shell/segments/hostname.py
@@ -1,3 +1,4 @@
+import os
 from ..utils import BasicSegment
 from ..color_compliment import stringToHashToColorAndOpposite
 from ..colortrans import rgb2short
@@ -7,6 +8,9 @@ from socket import gethostname
 class Segment(BasicSegment):
     def add_to_powerline(self):
         powerline = self.powerline
+        if powerline.segment_conf("hostname", "only_on_ssh"):
+            if not os.getenv('SSH_CLIENT'):
+                return
         if powerline.segment_conf("hostname", "colorize"):
             hostname = gethostname()
             FG, BG = stringToHashToColorAndOpposite(hostname)


### PR DESCRIPTION
This provides an option to enable the hostname segment only if connected via SSH.